### PR TITLE
virtualmachine/vmrun: fix an issue where machines with no display server could not boot VMs.

### DIFF
--- a/virtualmachine/vmrun/vm.go
+++ b/virtualmachine/vmrun/vm.go
@@ -4,6 +4,7 @@ package vmrun
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/ioutil"
@@ -161,9 +162,9 @@ func (vm *VM) Start() error {
 	_, vmxFileName := filepath.Split(src)
 	vm.VmxFilePath = fmt.Sprintf("%s/%s", dst, vmxFileName)
 
-	_, err := runner.RunCombinedError("start", vm.VmxFilePath)
+	out, err := runner.RunCombinedError("start", vm.VmxFilePath, "nogui")
 	if err != nil {
-		return err
+		return lvm.WrapErrors(err, errors.New(out))
 	}
 
 	return nil


### PR DESCRIPTION
I also wrapped the output of the vmrun command into the error, so that it's more visible when things fail.