### PR TITLE
Return an error if GetIPs failed

### DIFF
--- a/virtualmachine/mockprovider/vm.go
+++ b/virtualmachine/mockprovider/vm.go
@@ -17,11 +17,13 @@ type VM struct {
 	MockSuspend   func() error
 	MockResume    func() error
 	MockStart     func() error
-	MockGetIPs    func() []net.IP
+	MockGetIPs    func() ([]net.IP, error)
 	MockGetName   func() string
 	MockGetState  func() (string, error)
 	MockProvision func() error
 }
+
+var _ lvm.VirtualMachine = (*VM)(nil)
 
 // GetName returns the name of the virtual machine
 func (vm *VM) GetName() string {
@@ -80,11 +82,11 @@ func (vm *VM) Start() error {
 }
 
 // GetIPs returns a list of ip addresses associated with the vm through VMware tools
-func (vm *VM) GetIPs() []net.IP {
+func (vm *VM) GetIPs() ([]net.IP, error) {
 	if vm.MockGetIPs != nil {
 		return vm.MockGetIPs()
 	}
-	return []net.IP{}
+	return []net.IP{}, nil
 }
 
 // GetState gets the power state of the VM through VMware tools.

--- a/virtualmachine/virtualbox/vm.go
+++ b/virtualmachine/virtualbox/vm.go
@@ -93,7 +93,10 @@ func (vm *VM) GetName() string {
 // GetSSH returns an ssh client for the the vm.
 func (vm *VM) GetSSH(options libssh.Options) (libssh.Client, error) {
 	if len(vm.ips) == 0 {
-		ips := vm.GetIPs()
+		ips, err := vm.GetIPs()
+		if err != nil {
+			return nil, fmt.Errorf("Error getting IPs for the VM: %s", err)
+		}
 		if len(ips) == 0 {
 			return &libssh.SSHClient{}, lvm.ErrVMNoIP
 		}
@@ -159,10 +162,10 @@ func (vm *VM) Resume() error {
 }
 
 // GetIPs returns a list of ip addresses associated with the vm through VBox Guest Additions.
-func (vm *VM) GetIPs() []net.IP {
+func (vm *VM) GetIPs() ([]net.IP, error) {
 	vm.waitUntilReady()
 
-	return vm.ips
+	return vm.ips, nil
 }
 
 // GetState gets the power state of the VM being serviced by this driver.

--- a/virtualmachine/virtualmachine.go
+++ b/virtualmachine/virtualmachine.go
@@ -14,7 +14,7 @@ import (
 type VirtualMachine interface {
 	GetName() string
 	Provision() error
-	GetIPs() []net.IP
+	GetIPs() ([]net.IP, error)
 	Destroy() error
 	GetState() (string, error)
 	Suspend() error

--- a/virtualmachine/vmrun/vm.go
+++ b/virtualmachine/vmrun/vm.go
@@ -88,7 +88,10 @@ func (vm *VM) GetName() string {
 // GetSSH returns an ssh client for the the vm.
 func (vm *VM) GetSSH(options libssh.Options) (libssh.Client, error) {
 	if len(vm.ips) == 0 {
-		ips := vm.GetIPs()
+		ips, err := vm.GetIPs()
+		if err != nil {
+			return nil, fmt.Errorf("Error getting IPs for the VM: %s", err)
+		}
 		if len(ips) == 0 {
 			return nil, lvm.ErrVMNoIP
 		}
@@ -171,10 +174,10 @@ func (vm *VM) Start() error {
 }
 
 // GetIPs returns a list of ip addresses associated with the vm through VMware tools
-func (vm *VM) GetIPs() []net.IP {
+func (vm *VM) GetIPs() ([]net.IP, error) {
 	vm.waitUntilReady()
 
-	return vm.ips
+	return vm.ips, nil
 }
 
 // GetState gets the power state of the VM through VMware tools.


### PR DESCRIPTION
Previously, GetIPs was returning an empty slice if it failed, this
change adds support for bubbling up the error. Will address Virtualbox
error handling in a follow up PR>

Issue: #12 

@variadico  @zquestz 