### PR TITLE
Add IPs to ssh.Options

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -76,6 +76,7 @@ type Credentials struct {
 
 // Options provides SSH options like KeepAlive.
 type Options struct {
+	IPs       []net.IP
 	KeepAlive int
 }
 

--- a/virtualmachine/azure/vm.go
+++ b/virtualmachine/azure/vm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/apcera/libretto/Godeps/_workspace/src/github.com/Azure/azure-sdk-for-go/management/virtualmachine"
 	"github.com/apcera/libretto/Godeps/_workspace/src/github.com/Azure/azure-sdk-for-go/management/vmutils"
+	"github.com/apcera/libretto/util"
 
 	"github.com/apcera/libretto/ssh"
 	lvm "github.com/apcera/libretto/virtualmachine"
@@ -176,23 +177,19 @@ func (vm *VM) GetIPs() ([]net.IP, error) {
 
 // GetSSH returns an SSH client that can be used to connect to the VM. An error
 // is returned if the VM has no IPs.
-func (vm *VM) GetSSH(opts ssh.Options) (ssh.Client, error) {
-	ips, err := vm.GetIPs()
+func (vm *VM) GetSSH(options ssh.Options) (ssh.Client, error) {
+	ips, err := util.GetVMIPs(vm, options)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get ips: %s", err)
-	}
-	if ips == nil || len(ips) < 1 {
-		return nil, lvm.ErrVMNoIP
+		return nil, err
 	}
 
-	cli := ssh.SSHClient{
+	client := ssh.SSHClient{
 		Creds:   &vm.SSHCreds,
 		IP:      ips[PublicIP],
-		Options: opts,
+		Options: options,
 		Port:    22,
 	}
-
-	return &cli, nil
+	return &client, nil
 }
 
 // GetState returns the status of the Azure VM. The status will be one of the

--- a/virtualmachine/digitalocean/vm.go
+++ b/virtualmachine/digitalocean/vm.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	libssh "github.com/apcera/libretto/ssh"
+	"github.com/apcera/libretto/util"
 	lvm "github.com/apcera/libretto/virtualmachine"
 )
 
@@ -212,16 +213,12 @@ func (vm *VM) GetIPs() ([]net.IP, error) {
 
 // GetSSH returns an ssh client for the the vm.
 func (vm *VM) GetSSH(options libssh.Options) (libssh.Client, error) {
-	ips, err := vm.GetIPs()
+	ips, err := util.GetVMIPs(vm, options)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting IPs for the VM: %s", err)
-	}
-	if len(ips) == 0 {
-		return &libssh.SSHClient{}, lvm.ErrVMNoIP
+		return nil, err
 	}
 
 	client := libssh.SSHClient{Creds: &vm.Credentials, IP: ips[0], Port: 22, Options: options}
-
 	return &client, nil
 }
 

--- a/virtualmachine/openstack/vm.go
+++ b/virtualmachine/openstack/vm.go
@@ -15,6 +15,7 @@ import (
 	"github.com/apcera/libretto/Godeps/_workspace/src/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/apcera/libretto/Godeps/_workspace/src/github.com/rackspace/gophercloud/openstack/networking/v2/networks"
 	"github.com/apcera/libretto/ssh"
+	"github.com/apcera/libretto/util"
 	lvm "github.com/apcera/libretto/virtualmachine"
 )
 
@@ -382,12 +383,9 @@ func (vm *VM) Destroy() error {
 // GetSSH returns an SSH client that can be used to connect to a VM. An error is
 // returned if the VM has no IPs.
 func (vm *VM) GetSSH(options ssh.Options) (ssh.Client, error) {
-	ips, err := vm.GetIPs()
+	ips, err := util.GetVMIPs(vm, options)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting IPs for the VM: %s", err)
-	}
-	if ips == nil || len(ips) < 1 {
-		return nil, lvm.ErrVMNoIP
+		return nil, err
 	}
 
 	client := ssh.SSHClient{Creds: &vm.Credentials, IP: ips[PublicIP], Port: 22, Options: options}

--- a/virtualmachine/virtualbox/vm.go
+++ b/virtualmachine/virtualbox/vm.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/apcera/libretto/Godeps/_workspace/src/github.com/apcera/util/uuid"
+	"github.com/apcera/libretto/util"
 
 	libssh "github.com/apcera/libretto/ssh"
 	lvm "github.com/apcera/libretto/virtualmachine"
@@ -90,19 +91,15 @@ func (vm *VM) GetName() string {
 	return vm.Name
 }
 
-// GetSSH returns an ssh client for the the vm.
+// GetSSH returns an ssh client for the the VM.
 func (vm *VM) GetSSH(options libssh.Options) (libssh.Client, error) {
-	if len(vm.ips) == 0 {
-		ips, err := vm.GetIPs()
-		if err != nil {
-			return nil, fmt.Errorf("Error getting IPs for the VM: %s", err)
-		}
-		if len(ips) == 0 {
-			return &libssh.SSHClient{}, lvm.ErrVMNoIP
-		}
-		vm.ips = ips
+	ips, err := util.GetVMIPs(vm, options)
+	if err != nil {
+		return nil, err
 	}
-	client := libssh.SSHClient{Creds: &vm.Credentials, IP: vm.ips[0], Port: 22, Options: options}
+	vm.ips = ips
+
+	client := libssh.SSHClient{Creds: &vm.Credentials, IP: ips[0], Port: 22, Options: options}
 	return &client, nil
 }
 

--- a/virtualmachine/vmrun/vm.go
+++ b/virtualmachine/vmrun/vm.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	libssh "github.com/apcera/libretto/ssh"
+	"github.com/apcera/libretto/util"
 	lvm "github.com/apcera/libretto/virtualmachine"
 )
 
@@ -87,18 +88,13 @@ func (vm *VM) GetName() string {
 
 // GetSSH returns an ssh client for the the vm.
 func (vm *VM) GetSSH(options libssh.Options) (libssh.Client, error) {
-	if len(vm.ips) == 0 {
-		ips, err := vm.GetIPs()
-		if err != nil {
-			return nil, fmt.Errorf("Error getting IPs for the VM: %s", err)
-		}
-		if len(ips) == 0 {
-			return nil, lvm.ErrVMNoIP
-		}
-		vm.ips = ips
+	ips, err := util.GetVMIPs(vm, options)
+	if err != nil {
+		return nil, err
 	}
-	client := libssh.SSHClient{Creds: &vm.Credentials, IP: vm.ips[0], Port: 22, Options: options}
+	vm.ips = ips
 
+	client := libssh.SSHClient{Creds: &vm.Credentials, IP: ips[0], Port: 22, Options: options}
 	return &client, nil
 }
 

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -615,14 +615,12 @@ func (vm *VM) Resume() (err error) {
 }
 
 // GetSSH returns an ssh client configured for this VM.
-func (vm *VM) GetSSH(options ssh.Options) (c ssh.Client, err error) {
-	ips, err := vm.GetIPs()
+func (vm *VM) GetSSH(options ssh.Options) (ssh.Client, error) {
+	ips, err := util.GetVMIPs(vm, options)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting IPs for the VM: %s", err)
+		return nil, err
 	}
-	if len(ips) == 0 {
-		return nil, lvm.ErrVMNoIP
-	}
+
 	client := ssh.SSHClient{Creds: &vm.Credentials, IP: ips[0], Port: 22, Options: options}
 	return &client, nil
 }


### PR DESCRIPTION
Add a slice of `IPs` to the `ssh.Options` struct, so `IPs` can be passed into `GetSSH`, potentially avoiding an expensive `GetIPs` call. The `GetSSH` methods for all the VMs will not check the `options` argument first before calling `GetIPs`.

Also rename a few vars that were inconsistent between the different providers (e.g. `cli` -> `client`).

@lilirui @mbhinder @variadico 