### PR TITLE
Changed the Fusion provider to use gui mode again

### DIFF
--- a/virtualmachine/vmrun/vm.go
+++ b/virtualmachine/vmrun/vm.go
@@ -128,7 +128,9 @@ func (vm *VM) Halt() error {
 	_, vmxFileName := filepath.Split(src)
 	vm.VmxFilePath = fmt.Sprintf("%s/%s", dst, vmxFileName)
 
-	_, err := runner.RunCombinedError("stop", vm.VmxFilePath, "nogui")
+	// FIXME: Cannot use nogui flag here, it breaks vmrun's getGuestIP
+	// functionality.
+	_, err := runner.RunCombinedError("stop", vm.VmxFilePath)
 	if err != nil {
 		return err
 	}
@@ -144,6 +146,8 @@ func (vm *VM) Suspend() error {
 	_, vmxFileName := filepath.Split(src)
 	vm.VmxFilePath = fmt.Sprintf("%s/%s", dst, vmxFileName)
 
+	// FIXME: Cannot use nogui flag here, it breaks vmrun's getGuestIP
+	// functionality.
 	_, err := runner.RunCombinedError("suspend", vm.VmxFilePath)
 	if err != nil {
 		return err
@@ -165,7 +169,9 @@ func (vm *VM) Start() error {
 	_, vmxFileName := filepath.Split(src)
 	vm.VmxFilePath = fmt.Sprintf("%s/%s", dst, vmxFileName)
 
-	out, err := runner.RunCombinedError("start", vm.VmxFilePath, "nogui")
+	// FIXME: Cannot use nogui flag here, it breaks vmrun's getGuestIP
+	// functionality.
+	out, err := runner.RunCombinedError("start", vm.VmxFilePath)
 	if err != nil {
 		return lvm.WrapErrors(err, errors.New(out))
 	}
@@ -313,8 +319,9 @@ func (vm *VM) configure() error {
 // This function makes a single request to get IPs from a VM.
 func (vm *VM) requestIPs() []net.IP {
 	ips := []net.IP{}
-
-	stdout, _, _ := runner.Run("getGuestIPAddress", vm.VmxFilePath, "nogui", "wait")
+	// FIXME: Cannot use nogui flag here, it breaks vmrun's getGuestIP
+	// functionality.
+	stdout, _, _ := runner.Run("getGuestIPAddress", vm.VmxFilePath, "wait")
 	if stdout != "" {
 		if ip := net.ParseIP(strings.TrimSpace(stdout)); ip != nil {
 			ips = append(ips, ip)


### PR DESCRIPTION
We want to  use the `nogui` flag but using it breaks `getguestipaddress`
functionality in vmrun.

@zquestz @lilirui @erikh 

Using the `nogui` flag breaks vmrun's `getguestipaddress` and `runprograminguest` functionality. Both the commands return 

> Error: The virtual machine is not powered on

`vmrun checkToolsState` returns `installed` and verified that tools are running inside the VM.

 I'd found an old bug request somewhere on the VMware repos about this where they'd refused to fix it but can't locate it now. Changing this back to the old behavior for now.

