### PR TITLE
Added version constant to libretto.go - 0.9.0

### DIFF
--- a/libretto.go
+++ b/libretto.go
@@ -6,3 +6,5 @@
 // interfaces to achieve that, but the abstractions of their interfaces are
 // quite similar. See the README.md file for help getting started.
 package libretto
+
+const Version = "0.9.0"


### PR DESCRIPTION
Tiny change to add a version constant to the library. This uses semantic versioning, therefore it is set as a string. The caller would be responsible for parsing the value into major, minor, point.

@mbhinder @tw4dl @lilirui 