### PR TITLE
Fall back to the `guest.ipaddress` field if `guest.net` doesn't have ips

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -446,6 +446,12 @@ func (vm *VM) GetIPs() ([]net.IP, error) {
 			ips = append(ips, netIP)
 		}
 	}
+	if ips == nil && vmMo.Guest.IpAddress != "" {
+		ip := net.ParseIP(vmMo.Guest.IpAddress)
+		if ip != nil {
+			ips = append(ips, ip)
+		}
+	}
 	return ips, nil
 }
 


### PR DESCRIPTION
Govmomi `WaitForIp` only waits for the guest.ipaddress field to be
populated. We're using `guest.net` to get ips from the network cards.
This change adds a fallback to the `ipaddress` field if the network
cards don't have ips. This is likely when the VM has just booted up
because the `WaitForIp` method in the VMware library only waits for the
`ipaddress` field to be populated.

@y0ssar1an  @zquestz 