### PR TITLE
Fusion: Timeout while waiting for vmrun to execute.

### DIFF
--- a/virtualmachine/virtualmachine.go
+++ b/virtualmachine/virtualmachine.go
@@ -98,7 +98,9 @@ var (
 func WrapErrors(errs ...error) error {
 	s := []string{}
 	for _, e := range errs {
-		s = append(s, e.Error())
+		if e != nil {
+			s = append(s, e.Error())
+		}
 	}
 	return errors.New(strings.Join(s, ": "))
 }


### PR DESCRIPTION
* Adds a timeout while waiting for the vmrun utility to execute.
* Moved some type functions near the type definition
* Removed defer code from the delete function into the body of the function. This was discarding errors.
* Added a retry for the Halt method with the "hard" parameter.
* Nil check for "WrapErrors" to prevent formatting string panics

@zquestz @tw4dl 