### PR TITLE
Replace bad 'if err != nil' pattern

### DIFF
--- a/virtualmachine/azure/util.go
+++ b/virtualmachine/azure/util.go
@@ -106,11 +106,7 @@ func (vm *VM) deleteHostedService() error {
 
 	// Delete hosted service
 	_, err = sc.DeleteHostedService(vm.ServiceName, true)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // listHostedServices lists all the hosted services under the current account.
@@ -136,11 +132,7 @@ func (vm *VM) addAddCertificate() error {
 	}
 
 	_, err = sc.AddCertificate(vm.Name, vm.Cert.Data, hostedservice.CertificateFormat(vm.Cert.Format), vm.SSHCreds.SSHPassword)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // serviceExist checks if the desired service name already exists.

--- a/virtualmachine/azure/vm.go
+++ b/virtualmachine/azure/vm.go
@@ -144,12 +144,7 @@ func (vm *VM) Provision() error {
 		return err
 	}
 
-	err = cli.WaitForSSH(DefaultTimeout * time.Second)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return cli.WaitForSSH(DefaultTimeout * time.Second)
 }
 
 // GetIPs returns the IP addresses of the Azure VM instance.
@@ -234,12 +229,7 @@ func (vm *VM) Destroy() error {
 			vm.Name, vm.Name, err)
 	}
 
-	err = vm.deleteHostedService()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return vm.deleteHostedService()
 }
 
 // Halt shuts down the VM.

--- a/virtualmachine/openstack/vm.go
+++ b/virtualmachine/openstack/vm.go
@@ -445,12 +445,7 @@ func (vm *VM) Halt() error {
 	}
 
 	// Wait until VM halts
-	err = waitUntil(vm, lvm.VMHalted)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return waitUntil(vm, lvm.VMHalted)
 }
 
 // Start boots a stopped VM.
@@ -482,12 +477,7 @@ func (vm *VM) Start() error {
 	}
 
 	// Wait until the VM gets ready for SSH
-	err = waitUntilSSHReady(vm)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return waitUntilSSHReady(vm)
 }
 
 // Suspend always returns an error since we do not support for Openstack for now.

--- a/virtualmachine/virtualbox/util.go
+++ b/virtualmachine/virtualbox/util.go
@@ -231,10 +231,7 @@ func DeleteNIC(vm VM, nic NIC) error {
 		return lvm.ErrNICAlreadyDisabled
 	}
 	_, _, err := runner.Run("modifyvm", vm.Name, fmt.Sprintf("--nic%d", nic.Idx), "null")
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func getStringFromBacking(backing Backing) string {

--- a/virtualmachine/vmrun/vm.go
+++ b/virtualmachine/vmrun/vm.go
@@ -179,17 +179,12 @@ func (vm *VM) haltWithFlag(hard bool) error {
 	// FIXME: Cannot use nogui flag here, it breaks vmrun's getGuestIP
 	// functionality.
 	flag := "soft"
-	if (hard) {
+	if hard {
 		flag = "hard"
 	}
-		
+
 	_, err := runner.RunCombinedError("stop", vm.VmxFilePath, flag)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Halt powers off the VM without destroying it
@@ -208,11 +203,7 @@ func (vm *VM) Suspend() error {
 	// FIXME: Cannot use nogui flag here, it breaks vmrun's getGuestIP
 	// functionality.
 	_, err := runner.RunCombinedError("suspend", vm.VmxFilePath)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Resume suspends the active state of the VM.
@@ -367,12 +358,7 @@ func (vm *VM) configure() error {
 		newVmxString += b.String()
 	}
 
-	err = ioutil.WriteFile(vm.VmxFilePath, []byte(newVmxString), 0755)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return ioutil.WriteFile(vm.VmxFilePath, []byte(newVmxString), 0755)
 }
 
 // This function makes a single request to get IPs from a VM.


### PR DESCRIPTION
This is a small refactor that replaces all occurrences of this:
```
if err != nil {
    return err
}
return nil
```
...with this:
```
return err
```