### PR TITLE
Remove support for Go 1.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 
 language: go
 go:
-  - 1.4.3
   - 1.5.3
   - 1.6
   - tip
@@ -12,8 +11,6 @@ env:
     - BUILD_GOOS=linux
     - BUILD_GOOS=darwin
     - BUILD_GOOS=windows
-install:
-  - go get golang.org/x/tools/cmd/vet
 script:
   - go build
   - go vet ./...

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Supported Providers
 Getting Started
 ================
 
+Go version 1.5+ is required.
+
 `go get github.com/apcera/libretto/...`
 
 `go build ./...`


### PR DESCRIPTION
Go 1.4 isn't receiving security updates any more, so we should drop support for it and mention that in the README.

This has the side effect of fixing the build in Travis.