### PR TITLE
Add support for multiple volume creation on AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ vm := &aws.VM{
                 SSHUser:       "ubuntu",
                 SSHPrivateKey: string(rawKey),
         },
-        DeviceName:    "/dev/sda1",
+        Volumes: []aws.EBSVolume{
+            {
+                DeviceName: "/dev/sda1",
+            },
+        },
         Region:        "ap-northeast-1",
         KeyPair:       strings.TrimSuffix(filepath.Base(*key), filepath.Ext(*key)),
         SecurityGroup: "sg-9fdsfds",

--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -90,9 +90,7 @@ type VM struct {
 	InstanceID   string
 	KeyPair      string // required
 
-	DeviceName                   string
-	VolumeSize                   int
-	VolumeType                   string
+	Volumes                      []EBSVolume
 	KeepRootVolumeOnDestroy      bool
 	DeleteNonRootVolumeOnDestroy bool
 
@@ -102,6 +100,12 @@ type VM struct {
 
 	SSHCreds            ssh.Credentials // required
 	DeleteKeysOnDestroy bool
+}
+
+type EBSVolume struct {
+	DeviceName string
+	VolumeSize int
+	VolumeType string
 }
 
 // GetName returns the name of the virtual machine


### PR DESCRIPTION
For AWS API, we only have one volume tightly attached with VM struct, that breaks the flexibility to create multiple devices through libretto.
This adds the ability to allow user creates multiple EBS volumes for one VM instance fundamentally.

@variadico @mbhinder @zquestz @tw4dl 