### PR TITLE
Add methods to get private key and password

### DIFF
--- a/ssh/mock_ssh.go
+++ b/ssh/mock_ssh.go
@@ -73,6 +73,14 @@ func (c *MockSSHClient) SetSSHPrivateKey(s string) {
 	return
 }
 
+// GetSSHPrivateKey calls the mocked GetSSHPrivateKey
+func (c *MockSSHClient) GetSSHPrivateKey() string {
+	if c.MockGetSSHPrivateKey != nil {
+		return c.MockGetSSHPrivateKey()
+	}
+	return ""
+}
+
 // SetSSHPassword calls the mocked SetSSHPassword
 func (c *MockSSHClient) SetSSHPassword(s string) {
 	if c.MockSetSSHPassword != nil {
@@ -80,4 +88,12 @@ func (c *MockSSHClient) SetSSHPassword(s string) {
 		return
 	}
 	return
+}
+
+// GetSSHPassword calls the mocked GetSSHPassword
+func (c *MockSSHClient) GetSSHPassword() string {
+	if c.MockGetSSHPassword != nil {
+		return c.MockGetSSHPassword()
+	}
+	return ""
 }

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -64,7 +64,9 @@ type Client interface {
 	WaitForSSH(maxWait time.Duration) error
 
 	SetSSHPrivateKey(string)
+	GetSSHPrivateKey() string
 	SetSSHPassword(string)
+	GetSSHPassword() string
 }
 
 // Credentials supplies SSH credentials.
@@ -102,7 +104,9 @@ type MockSSHClient struct {
 	MockWaitForSSH func(maxWait time.Duration) error
 
 	MockSetSSHPrivateKey func(string)
+	MockGetSSHPrivateKey func() string
 	MockSetSSHPassword   func(string)
+	MockGetSSHPassword   func() string
 }
 
 // dial will attempt to connect to an SSH server.
@@ -434,5 +438,11 @@ func (client *SSHClient) WaitForSSH(maxWait time.Duration) error {
 // SetSSHPrivateKey sets the private key on the clients credentials.
 func (client *SSHClient) SetSSHPrivateKey(s string) { client.Creds.SSHPrivateKey = s }
 
+// GetSSHPrivateKey gets the private key on the clients credentials.
+func (client *SSHClient) GetSSHPrivateKey() string { return client.Creds.SSHPrivateKey }
+
 // SetSSHPassword sets the SSH password on the clients credentials.
 func (client *SSHClient) SetSSHPassword(s string) { client.Creds.SSHPassword = s }
+
+// GetSSHPassword gets the SSH password on the clients credentials.
+func (client *SSHClient) GetSSHPassword() string { return client.Creds.SSHPassword }


### PR DESCRIPTION
Currently the ssh.Client interface provided setters for passwords
and private keys but not getters. This change provides those
methods.

@zquestz @mbhinder @variadico @lilirui @y0ssar1an 