### PR TITLE
Add mutex to guard SSHClient Credentials

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -71,6 +71,7 @@ type Client interface {
 
 // Credentials supplies SSH credentials.
 type Credentials struct {
+	mu            sync.Mutex
 	SSHUser       string
 	SSHPassword   string
 	SSHPrivateKey string
@@ -436,13 +437,29 @@ func (client *SSHClient) WaitForSSH(maxWait time.Duration) error {
 }
 
 // SetSSHPrivateKey sets the private key on the clients credentials.
-func (client *SSHClient) SetSSHPrivateKey(s string) { client.Creds.SSHPrivateKey = s }
+func (client *SSHClient) SetSSHPrivateKey(s string) {
+	client.Creds.mu.Lock()
+	client.Creds.SSHPrivateKey = s
+	client.Creds.mu.Unlock()
+}
 
 // GetSSHPrivateKey gets the private key on the clients credentials.
-func (client *SSHClient) GetSSHPrivateKey() string { return client.Creds.SSHPrivateKey }
+func (client *SSHClient) GetSSHPrivateKey() string {
+	client.Creds.mu.Lock()
+	defer client.Creds.mu.Unlock()
+	return client.Creds.SSHPrivateKey
+}
 
 // SetSSHPassword sets the SSH password on the clients credentials.
-func (client *SSHClient) SetSSHPassword(s string) { client.Creds.SSHPassword = s }
+func (client *SSHClient) SetSSHPassword(s string) {
+	client.Creds.mu.Lock()
+	client.Creds.SSHPassword = s
+	client.Creds.mu.Unlock()
+}
 
 // GetSSHPassword gets the SSH password on the clients credentials.
-func (client *SSHClient) GetSSHPassword() string { return client.Creds.SSHPassword }
+func (client *SSHClient) GetSSHPassword() string {
+	client.Creds.mu.Lock()
+	defer client.Creds.mu.Unlock()
+	return client.Creds.SSHPassword
+}


### PR DESCRIPTION
```go
client1 := vm.GetSSH()
client2 := vm.GetSSH()
fmt.Println(client1.GetSSHPassword()) // "foo"
go client1.SetSSHPassword("bar")      // also mutates vm and client2
fmt.Println(client2.GetSSHPassword()) // undefined
```
The SSH `Creds` are passed by reference from the `VirtualMachine` object to its SSH clients. The Getters and Setters for those SSH creds are defined on the clients, not on the VM object itself. Calling a setter on the client has side effects for the VM object and for all other clients.

Add a mutex to guard against the undefined behavior.

FIxes #47 

@johnSchnake @mbhinder @variadico 