### PR TITLE
Fixed retrieving the state for deleted Azure VM

### DIFF
--- a/virtualmachine/azure/arm/vm.go
+++ b/virtualmachine/azure/arm/vm.go
@@ -220,7 +220,8 @@ func (vm *VM) Destroy() error {
 	for i := 0; i < actionTimeout; i++ {
 		_, err := vm.GetState()
 		if err != nil {
-			if strings.Contains(err.Error(), `Code="ResourceNotFound"`) {
+			if strings.Contains(err.Error(), `Code="ResourceNotFound"`) ||
+				strings.Contains(err.Error(), `Code="NotFound"`) {
 				deleted = true
 				break
 			}


### PR DESCRIPTION
Currently when a state is being requested for a deleted VM, the Azure
returns an error including a specific ResourceNotFound message. In some cases,
the Azure returns an error with NotFound message instead of ResourceNotFound.
This commit covers this case as well.