### PR TITLE
Fixed azure arm panic when no private or public ip returned

### DIFF
--- a/virtualmachine/azure/arm/util.go
+++ b/virtualmachine/azure/arm/util.go
@@ -182,7 +182,8 @@ func (vm *VM) getPublicIP(authorizer *azure.ServicePrincipalToken) (net.IP, erro
 		return nil, err
 	}
 
-	if resPublicIP.Properties == nil || *resPublicIP.Properties.IPAddress == "" {
+	if resPublicIP.Properties == nil || resPublicIP.Properties.IPAddress == nil ||
+		*resPublicIP.Properties.IPAddress == "" {
 		return nil, fmt.Errorf("VM has no public IP address")
 	}
 	return net.ParseIP(*resPublicIP.Properties.IPAddress), nil
@@ -198,7 +199,8 @@ func (vm *VM) getPrivateIP(authorizer *azure.ServicePrincipalToken) (net.IP, err
 		return nil, err
 	}
 
-	if resPrivateIP.Properties == nil || len(*resPrivateIP.Properties.IPConfigurations) == 0 {
+	if resPrivateIP.Properties == nil || resPrivateIP.Properties.IPConfigurations == nil ||
+		len(*resPrivateIP.Properties.IPConfigurations) == 0 {
 		return nil, fmt.Errorf("VM has no private IP address")
 	}
 	ipConfigs := *resPrivateIP.Properties.IPConfigurations


### PR DESCRIPTION
Once in a while, azure do not return any IP address during public IP and private IP creation. So, this PR resolves the panic for this case.
@lilirui @zquestz 