### PR TITLE
Increased the SSH timeout for Azure arm

### DIFF
--- a/virtualmachine/azure/arm/vm.go
+++ b/virtualmachine/azure/arm/vm.go
@@ -31,7 +31,7 @@ const (
 	PrivateIP = 1
 
 	// sshTimeout is the maximum seconds to wait before failing to GetSSH.
-	sshTimeout = 60
+	sshTimeout = 180
 
 	// actionTimeout is the maximum seconds to wait before failing to
 	// any action on VM, such as Provision, Halt or Destroy.


### PR DESCRIPTION
Sometimes, 60 seconds is not enough for VM to get SSH ready on Azure. So, i increased the limit to 180 seconds.

@lilirui @mbhinder 