### PR TITLE
Created unique deployment names for provisioning Azure VMs on ARM

### DIFF
--- a/virtualmachine/azure/arm/util.go
+++ b/virtualmachine/azure/arm/util.go
@@ -149,14 +149,14 @@ func (vm *VM) deploy() error {
 	deploymentsClient := resources.NewDeploymentsClient(vm.Creds.SubscriptionID)
 	deploymentsClient.Authorizer = authorizer
 
-	_, err = deploymentsClient.CreateOrUpdate(vm.ResourceGroup, deploymentName, *deployment, nil)
+	_, err = deploymentsClient.CreateOrUpdate(vm.ResourceGroup, vm.deploymentName, *deployment, nil)
 	if err != nil {
 		return err
 	}
 
 	// Make sure the deployment is succeeded
 	for i := 0; i < actionTimeout; i++ {
-		result, err := deploymentsClient.Get(vm.ResourceGroup, deploymentName)
+		result, err := deploymentsClient.Get(vm.ResourceGroup, vm.deploymentName)
 		if err != nil {
 			return err
 		}

--- a/virtualmachine/azure/arm/vm.go
+++ b/virtualmachine/azure/arm/vm.go
@@ -46,9 +46,6 @@ const (
 	// succeeded is the status returned when a deployment ends successfully
 	succeeded = "Succeeded"
 
-	// deploymentName is the deployment name when provisioning a VM
-	deploymentName = "libretto"
-
 	// maxPublicIPLength is the maximum length that public ip can have
 	maxPublicIPLength = 63
 )
@@ -94,6 +91,9 @@ type VM struct {
 	PublicIP             string
 	Subnet               string
 	VirtualNetwork       string
+
+	// deployment
+	deploymentName string
 }
 
 // GetName returns the name of the VM.
@@ -115,6 +115,7 @@ func (vm *VM) Provision() error {
 	vm.OsFile = tempName + "-os-disk.vhd"
 	vm.PublicIP = tempName + "-public-ip"
 	vm.Nic = tempName + "-nic"
+	vm.deploymentName = tempName + "-deploy"
 
 	publicIPLength := len(vm.PublicIP)
 	if publicIPLength > maxPublicIPLength {


### PR DESCRIPTION
We have to give unique names to the deployment name while provisioning Azure ARM VMs. Otherwise, 2 Azure ARM VM cannot be provisioned at the same time.

@lilirui @mbhinder 