### PR TITLE
Remove unused variables

### DIFF
--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -23,9 +23,6 @@ const (
 	// PrivateIP is the index of the private IP address that GetIPs returns.
 	PrivateIP = 1
 
-	// ProvisionTimeout is the maximum seconds to wait before failing to
-	// provision.
-	ProvisionTimeout = 90
 	// SSHTimeout is the maximum time to wait before failing to GetSSH.
 	SSHTimeout = 5 * time.Minute
 

--- a/virtualmachine/aws/wait.go
+++ b/virtualmachine/aws/wait.go
@@ -16,7 +16,6 @@ type ReadyError struct {
 
 	ImageID               string
 	InstanceID            string
-	InstanceStateName     string
 	InstanceType          string
 	LaunchTime            time.Time
 	PublicIPAddress       string


### PR DESCRIPTION
I noticed that these variables don't get used in `virtualmachine/aws`. They probably did at some point, but weren't cleaned up during some refactor.

@davidweishi @lilirui @y0ssar1an @zquestz