### PR TITLE
Search more possible path for vmrun.exe

### DIFF
--- a/virtualmachine/vmrun/vm.go
+++ b/virtualmachine/vmrun/vm.go
@@ -43,6 +43,9 @@ const vmrunTimeout = 90 * time.Second
 // ErrVmrunTimeout is returned when vmrun doesn't finish executing in `vmrunTimeout` seconds.
 var ErrVmrunTimeout = errors.New("Timed out waiting for vmrun")
 
+// ErrVmrunNotFound is returned when no vmrun was found in host.
+var ErrVmrunNotFound = errors.New("Failed to find vmrun")
+
 // Regular expression to parse the VMX file
 var ethernetRegexp = regexp.MustCompile(`ethernet.*\n`)
 
@@ -84,6 +87,10 @@ func (f vmrunRunner) Run(args ...string) (string, string, error) {
 		vmrunPath = path
 	} else {
 		vmrunPath = VMRunPath
+	}
+
+	if vmrunPath == "" {
+		return "", "", ErrVmrunNotFound
 	}
 
 	cmd := exec.Command(vmrunPath, args...)

--- a/virtualmachine/vmrun/vm_windows.go
+++ b/virtualmachine/vmrun/vm_windows.go
@@ -9,9 +9,18 @@ import (
 	"path/filepath"
 )
 
-// Hardcoded path to vmrun to fallback when it is not on path.
+// VMRunPath is default path to vmrun to fallback when it is not on path.
 var VMRunPath string
 
+// VMwareProducts define VMware products those contain vmrun.exe in Windows.
+var VMwareProducts = [3]string{"VMware Workstation", "VMWare Player", "VMware VIX"}
+
 func init() {
-	VMRunPath = filepath.Join(os.Getenv("ProgramFiles"), "VMware", "VMware VIX", "vmrun.exe")
+	for _, products := range VMwareProducts {
+		path := filepath.Join(os.Getenv("ProgramFiles"), "VMware", products, "vmrun.exe")
+		if _, err := os.Stat(path); err == nil {
+			VMRunPath = path
+			break
+		}
+	}
 }

--- a/virtualmachine/vmrun/vm_windows_amd64.go
+++ b/virtualmachine/vmrun/vm_windows_amd64.go
@@ -9,9 +9,18 @@ import (
 	"path/filepath"
 )
 
-// Hardcoded path to vmrun to fallback when it is not on path.
+// VMRunPath is default path to vmrun to fallback when it is not on path.
 var VMRunPath string
 
+// VMwareProducts define VMware products those contain vmrun.exe in Windows.
+var VMwareProducts = [3]string{"VMware Workstation", "VMware Player", "VMware VIX"}
+
 func init() {
-	VMRunPath = filepath.Join(os.Getenv("ProgramFiles(x86)"), "VMware", "VMware VIX", "vmrun.exe")
+	for _, products := range VMwareProducts {
+		path := filepath.Join(os.Getenv("ProgramFiles(x86)"), "VMware", products, "vmrun.exe")
+		if _, err := os.Stat(path); err == nil {
+			VMRunPath = path
+			break
+		}
+	}
 }


### PR DESCRIPTION
Previouslly we search vmrun from system path, if it was not found then pick default path, however there are multiple locations on Windows for diffrient VMWare products.
This change will interate those possilbe directories and make sure we can find a validate path, otherwise will throw error to indicate the problem.


@zquestz @mbhinder @variadico @y0ssar1an 

