### PR TITLE
Add options to allow user providing cloud-init scripts and set admin pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,15 @@ vm := &gcp.VM{
 
 ``` go
 
-    metadata := openstack.NewDefaultImageMetadata()
+
+  metadata := openstack.NewDefaultImageMetadata()
   volume := openstack.NewDefaultVolume()
+
+  // Optional
+  cloudInit, err := ioutil.ReadFile("/your/user/data")
+  if err != nil {
+      return err
+  }
 
   vm := &openstack.VM{
     IdentityEndpoint: os.Getenv("OS_AUTH_URL"),
@@ -249,6 +256,8 @@ vm := &gcp.VM{
     FloatingIPPool:   "net04_ext",
     FloatingIP:       nil,
     SecurityGroup:    "test",
+    AdminPassword:    os.Getenv("OS_ADMIN_PASSWORD"),
+    UserData:         cloudInit,
     Credentials: ssh.Credentials{
       SSHUser:     "ubuntu",
       SSHPassword: "ubuntu",

--- a/virtualmachine/openstack/vm.go
+++ b/virtualmachine/openstack/vm.go
@@ -158,6 +158,14 @@ type VM struct {
 	// SecurityGroup represents the name of the security group to which this VM should belong
 	SecurityGroup string
 
+	// UserData [optional] contains configuration information or scripts to use upon launch,
+	// known as cloud-init scripts.
+	UserData []byte
+
+	// AdminPassword [optional] sets the root user password. If not set, a randomly-generated password
+	// will be created by OpenStack API.
+	AdminPassword string
+
 	// Credentials are the credentials to use when connecting to the VM over SSH
 	Credentials ssh.Credentials
 
@@ -223,6 +231,8 @@ func (vm *VM) Provision() error {
 		ImageRef:       imageID,
 		Networks:       listOfNetworks,
 		SecurityGroups: []string{securityGroup},
+		UserData:       vm.UserData,
+		AdminPass:      vm.AdminPassword,
 	}
 
 	server, err := servers.Create(client, createOpts).Extract()


### PR DESCRIPTION
Previously we only support create VM from pre-built OpenStack image that includes already defined username and password. This change allows Libretto to launch public/generic images [e.g. http://cloud.centos.org/centos/7/images/] by configuring your password or setup scripts through cloud-init on demand.

@yaso195 @variadico  @zquestz