### PR TITLE
Validate slice length to prevent panic

### DIFF
--- a/virtualmachine/azure/arm/vm.go
+++ b/virtualmachine/azure/arm/vm.go
@@ -187,7 +187,7 @@ func (vm *VM) GetState() (string, error) {
 	virtualMachinesClient.Authorizer = authorizer
 
 	r, e := virtualMachinesClient.Get(vm.ResourceGroup, vm.Name, "InstanceView")
-	if r.Properties != nil && r.Properties.InstanceView != nil {
+	if r.Properties != nil && r.Properties.InstanceView != nil && len(*r.Properties.InstanceView.Statuses) > 0 {
 		state := *(*r.Properties.InstanceView.Statuses)[1].DisplayStatus
 		return translateState(state), e
 	}


### PR DESCRIPTION
This fixes a panic we saw in the test, just add the validation for the slice length to make sure the code is safe.

@yaso195 @zquestz @variadico 