### PR TITLE
Deleted the arm template on Azure VM destroy

### DIFF
--- a/virtualmachine/azure/arm/util.go
+++ b/virtualmachine/azure/arm/util.go
@@ -252,6 +252,17 @@ func (vm *VM) deletePublicIP(authorizer *azure.ServicePrincipalToken) error {
 	return err
 }
 
+// deleteDeployment deletes the deployed azure arm template for this vm.
+func (vm *VM) deleteDeployment(authorizer *azure.ServicePrincipalToken) error {
+	// Get the deployments client
+	deploymentsClient := resources.NewDeploymentsClient(vm.Creds.SubscriptionID)
+	deploymentsClient.Authorizer = authorizer
+
+	// Delete the deployment
+	_, err := deploymentsClient.Delete(vm.ResourceGroup, vm.deploymentName, nil)
+	return err
+}
+
 func createDeployment(template string, params armParameters) (*resources.Deployment, error) {
 	templateMap, err := unmarshalTemplate(template)
 	if err != nil {

--- a/virtualmachine/azure/arm/vm.go
+++ b/virtualmachine/azure/arm/vm.go
@@ -244,7 +244,13 @@ func (vm *VM) Destroy() error {
 	}
 
 	// Delete the public IP of this VM
-	return vm.deletePublicIP(authorizer)
+	err = vm.deletePublicIP(authorizer)
+	if err != nil {
+		return err
+	}
+
+	// Delete the deployed arm template
+	return vm.deleteDeployment(authorizer)
 }
 
 // Halt shuts down the VM.


### PR DESCRIPTION
Apparently, each resource group has a limit of 800 arm template deployments. So during destroy, we need to clean up the arm template that is used for creating the VM. 

Fixes #ENGT-9413

@lilirui @zquestz 