### PR TITLE
vsphere: Answer questions attached to VM when possible.

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -336,6 +336,11 @@ type VM struct {
 	Credentials ssh.Credentials
 	// Disks is a slice of extra disks to attach to the VM
 	Disks []Disk
+	// QuestionResponses is a map of regular expressions to match question text
+	// to responses when a VM encounters a questions which would otherwise
+	// prevent normal operation. The response strings should be the string value
+	// of the intended response index.
+	QuestionResponses map[string]string
 
 	uri       *url.URL
 	ctx       context.Context


### PR DESCRIPTION
If there are questions pending on a VM, the destroy operation
may fail repeatedly. It should be possible to answer questions
with a preferred answer.

There are also default options attached to questions and it may
be reasonable to answer all questions with the default unless
overwridden with a specific answer. However, this first change
just tries to answer only the predefined ones.

Note: There are no IDs for question types, which is why you must
store answers to questions keyed off of regular expressions.

Addresses issue #68

@mbhinder @sdemura @lilirui 