### PR TITLE
Update test to be compatible with go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 
 language: go
 go:
-  - 1.5.4
   - 1.6.2
+  - 1.7.3
   - tip
 os:
   - linux

--- a/virtualmachine/vsphere/vm_test.go
+++ b/virtualmachine/vsphere/vm_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -703,9 +704,10 @@ func TestUploadOvfHappyPath(t *testing.T) {
 }
 
 func TestCreateRequestNewRequestError(t *testing.T) {
+	errProtocol := `unsupported protocol scheme ""`
 	err := createRequest(mockProgressReader{}, "foo", true, 0, "", "foo")
-	if err.Error() != `unsupported protocol scheme ""` {
-		t.Fatalf("Expected to get protocol error, got: %s", err)
+	if !strings.Contains(err.Error(), errProtocol) {
+		t.Fatalf("Expected error to contain %q, got: %q", errProtocol, err)
 	}
 }
 


### PR DESCRIPTION
A slight change in the text of an error caused the build to be
failing. This change updates the test to work with both versions
and also updates the travis configuration to no longer test
go1.5 and adds go1.7.

@mbhinder @zquestz @yaso195 @lilirui 