### PR TITLE
Update Go versions to 1.6.4 and 1.7.4 in travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
-
 language: go
+
 go:
-  - 1.6.2
-  - 1.7.3
+  - 1.6
+  - 1.7
   - tip
+
 os:
   - linux
   - osx
+
 env:
-  global:
-    - GO15VENDOREXPERIMENT=1
   matrix:
     - BUILD_GOARCH=amd64
     - BUILD_GOARCH=386
-install: true # avoids go get. assumes all necessary code is in the repo
+
+# don't go get deps. will only build with code in vendor directory.
+install: true
+
 script:
-  - go build
   - go vet $(go list ./... | grep -v /vendor/)
   - go test -v -race $(go list ./... | grep -v /vendor/)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Supported Providers
 Getting Started
 ================
 
-Go version 1.5+ is required.
+Go version 1.6+ is required.
 
 `go get github.com/apcera/libretto/...`
 


### PR DESCRIPTION
I just bumped the Go versions we're testing on to the latest point releases. I also removed setting `GO15VENDOREXPERIMENT=1` because it's enabled by default as of Go 1.6.