### PR TITLE
Run gosimple as part of our Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,15 @@ env:
     - BUILD_GOARCH=amd64
     - BUILD_GOARCH=386
 
+before_install:
+  - go get -u honnef.co/go/simple/cmd/gosimple
+
 # don't go get deps. will only build with code in vendor directory.
 install: true
 
 script:
-  - go vet $(go list ./... | grep -v /vendor/)
-  - go test -v -race $(go list ./... | grep -v /vendor/)
+  # pkgs avoids testing anything in vendor/
+  - pkgs=$(go list ./... | grep -v /vendor/)
+  - go vet $pkgs
+  - go test -v -race $pkgs
+  - gosimple $pkgs


### PR DESCRIPTION
This adds the [`gosimple`](https://github.com/dominikh/go-simple) linter back into Travis. We were using `gosimple` previously but had to remove it because the vanity URL server was crashing, causing Travis builds to fail because they couldn't `go get` it.

There's still a risk that the vanity URL server might go down, but [the author has moved it to Google's network](https://github.com/dominikh/go-simple/issues/22#issuecomment-252401996), so the risk is small.