### PR TITLE
Replace deprecated session.New method with session.NewSession for AWS

### DIFF
--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -35,7 +35,12 @@ const (
 // ValidCredentials sends a dummy request to AWS to check if credentials are
 // valid. An error is returned if credentials are missing or region is missing.
 func ValidCredentials(region string) error {
-	_, err := getService(region).DescribeInstances(nil)
+	svc, err := getService(region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS service: %v", err)
+	}
+
+	_, err = svc.DescribeInstances(nil)
 	awsErr, isAWS := err.(awserr.Error)
 	if !isAWS {
 		return err
@@ -131,7 +136,7 @@ func setNonRootDeleteOnDestroy(svc *ec2.EC2, instID string, delOnTerm bool) erro
 	return nil
 }
 
-func getService(region string) *ec2.EC2 {
+func getService(region string) (*ec2.EC2, error) {
 	creds := credentials.NewChainCredentials(
 		[]credentials.Provider{
 			&credentials.EnvProvider{},               // check environment
@@ -146,12 +151,17 @@ func getService(region string) *ec2.EC2 {
 		}
 	}
 
-	return ec2.New(session.New(&aws.Config{
+	s, err := session.NewSession(&aws.Config{
 		Credentials: creds,
 		Region:      &region,
 		CredentialsChainVerboseErrors: aws.Bool(true),
 		HTTPClient:                    &http.Client{Timeout: 30 * time.Second},
-	}))
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AWS session: %v", err)
+	}
+
+	return ec2.New(s), nil
 }
 
 func instanceInfo(vm *VM) *ec2.RunInstancesInput {
@@ -229,9 +239,12 @@ func hasInstanceID(instance *ec2.Instance) bool {
 // UploadKeyPair uploads the public key to AWS with a given name.
 // If the public key already exists, then no error is returned.
 func UploadKeyPair(publicKey []byte, name string, region string) error {
-	svc := getService(region)
+	svc, err := getService(region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS service: %v", err)
+	}
 
-	_, err := svc.ImportKeyPair(&ec2.ImportKeyPairInput{
+	_, err = svc.ImportKeyPair(&ec2.ImportKeyPairInput{
 		KeyName:           aws.String(name),
 		PublicKeyMaterial: publicKey,
 		DryRun:            aws.Bool(false),
@@ -249,13 +262,16 @@ func UploadKeyPair(publicKey []byte, name string, region string) error {
 
 // DeleteKeyPair deletes the given key pair from the given region.
 func DeleteKeyPair(name string, region string) error {
-	svc := getService(region)
+	svc, err := getService(region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS service: %v", err)
+	}
 
 	if name == "" {
 		return errors.New("Missing key pair name")
 	}
 
-	_, err := svc.DeleteKeyPair(&ec2.DeleteKeyPairInput{
+	_, err = svc.DeleteKeyPair(&ec2.DeleteKeyPairInput{
 		KeyName: aws.String(name),
 		DryRun:  aws.Bool(false),
 	})

--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -103,7 +103,10 @@ func (vm *VM) GetName() string {
 
 // SetTag adds a tag to the VM and its attached volumes.
 func (vm *VM) SetTag(key, value string) error {
-	svc := getService(vm.Region)
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS service: %v", err)
+	}
 
 	if vm.InstanceID == "" {
 		return ErrNoInstanceID
@@ -139,7 +142,10 @@ func (vm *VM) SetTag(key, value string) error {
 // if the VM takes too long to enter "running" state.
 func (vm *VM) Provision() error {
 	<-limiter
-	svc := getService(vm.Region)
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS service: %v", err)
+	}
 
 	resp, err := svc.RunInstances(instanceInfo(vm))
 	if err != nil {
@@ -167,7 +173,11 @@ func (vm *VM) Provision() error {
 // PrivateIP consts can be used to retrieve respective IP address type. It
 // returns nil if there was an error obtaining the IPs.
 func (vm *VM) GetIPs() ([]net.IP, error) {
-	svc := getService(vm.Region)
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AWS service: %v", err)
+	}
+
 	if vm.InstanceID == "" {
 		// Probably need to call Provision first.
 		return nil, ErrNoInstanceID
@@ -203,12 +213,16 @@ func (vm *VM) GetIPs() ([]net.IP, error) {
 // Destroy terminates the VM on AWS. It returns an error if AWS credentials are
 // missing or if there is no instance ID.
 func (vm *VM) Destroy() error {
-	svc := getService(vm.Region)
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS service: %v", err)
+	}
+
 	if vm.InstanceID == "" {
 		// Probably need to call Provision first.
 		return ErrNoInstanceID
 	}
-	_, err := svc.TerminateInstances(&ec2.TerminateInstancesInput{
+	_, err = svc.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: []*string{
 			aws.String(vm.InstanceID),
 		},
@@ -249,7 +263,10 @@ func (vm *VM) GetSSH(options ssh.Options) (ssh.Client, error) {
 // returned if the instance ID is missing, if there was a problem querying AWS,
 // or if there are no instances.
 func (vm *VM) GetState() (string, error) {
-	svc := getService(vm.Region)
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return "", fmt.Errorf("failed to get AWS service: %v", err)
+	}
 
 	if vm.InstanceID == "" {
 		// Probably need to call Provision first.
@@ -277,14 +294,17 @@ func (vm *VM) GetState() (string, error) {
 
 // Halt shuts down the VM on AWS.
 func (vm *VM) Halt() error {
-	svc := getService(vm.Region)
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS service: %v", err)
+	}
 
 	if vm.InstanceID == "" {
 		// Probably need to call Provision first.
 		return ErrNoInstanceID
 	}
 
-	_, err := svc.StopInstances(&ec2.StopInstancesInput{
+	_, err = svc.StopInstances(&ec2.StopInstancesInput{
 		InstanceIds: []*string{
 			aws.String(vm.InstanceID),
 		},
@@ -300,14 +320,17 @@ func (vm *VM) Halt() error {
 
 // Start boots a stopped VM.
 func (vm *VM) Start() error {
-	svc := getService(vm.Region)
+	svc, err := getService(vm.Region)
+	if err != nil {
+		return fmt.Errorf("failed to get AWS service: %v", err)
+	}
 
 	if vm.InstanceID == "" {
 		// Probably need to call Provision first.
 		return ErrNoInstanceID
 	}
 
-	_, err := svc.StartInstances(&ec2.StartInstancesInput{
+	_, err = svc.StartInstances(&ec2.StartInstancesInput{
 		InstanceIds: []*string{
 			aws.String(vm.InstanceID),
 		},


### PR DESCRIPTION
The `session.New` function in `aws-sdk-go` has been deprecated in favor of `session.NewSession`. These `Session` objects are part of the API to create connections to EC2. These functions search for credentials in the `.aws` files on your local machine. The only difference between them is that `session.NewSession` will return an error if fails during a read from `.aws`. So the code change is just...
1) returning an error from `getService` (which calls `session.NewSession`)
2) handling that error