### PR TITLE
Linked Clone Support in vSphere

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -262,6 +262,14 @@ type Disk struct {
 	Controller string
 }
 
+// Snapshot represents a vSphere snapshot to create
+type snapshot struct {
+	Name        string
+	Description string
+	Memory      bool
+	Quiesce     bool
+}
+
 type finder interface {
 	DatacenterList(context.Context, string) ([]*object.Datacenter, error)
 }
@@ -326,7 +334,6 @@ type VM struct {
 	Template string
 	// Datastores is a slice of permissible datastores. One is picked out of these.
 	Datastores []string
-
 	// UseLocalTemplates is a flag to indicate whether a template should be uploaded on all
 	// the datastores that were passed in.
 	UseLocalTemplates bool
@@ -341,14 +348,16 @@ type VM struct {
 	// prevent normal operation. The response strings should be the string value
 	// of the intended response index.
 	QuestionResponses map[string]string
-
-	uri       *url.URL
-	ctx       context.Context
-	cancel    context.CancelFunc
-	client    *govmomi.Client
-	finder    finder
-	collector collector
-	datastore string
+	// UseLinkedClones is a flag to indicate whether VMs cloned from templates should be
+	// linked clones.
+	UseLinkedClones bool
+	uri             *url.URL
+	ctx             context.Context
+	cancel          context.CancelFunc
+	client          *govmomi.Client
+	finder          finder
+	collector       collector
+	datastore       string
 }
 
 // Provision provisions this VM.


### PR DESCRIPTION
This PR adds linked clone support for the vSphere provisioner.

In order to use linked clones, the template must be a VM and not
marked as a template, so when we upload the OFV and deploy it,
if UseLinkedClones is set to true, we will not mark it as a template
but instead create a snapshot.

When cloneFromTemplate is called, if UseLinkedClones is set, then we will create a clone from the snapshot and set the DiskMoveType to "createNewChildDiskBacking", which in turn gives us a linked clone.

@bwerthmann @zquestz @johnSchnake @earlruby 