### PR TITLE
Have instance name set in AWS if name is set

### DIFF
--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -13,8 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -141,9 +139,8 @@ func setNonRootDeleteOnDestroy(svc *ec2.EC2, instID string, delOnTerm bool) erro
 func getService(region string) (*ec2.EC2, error) {
 	creds := credentials.NewChainCredentials(
 		[]credentials.Provider{
-			&credentials.EnvProvider{},                                            // check environment
-			&credentials.SharedCredentialsProvider{},                              // check home dir
-			&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New())}, // check metadata
+			&credentials.EnvProvider{},               // check environment
+			&credentials.SharedCredentialsProvider{}, // check home dir
 		},
 	)
 

--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -13,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
@@ -139,8 +141,9 @@ func setNonRootDeleteOnDestroy(svc *ec2.EC2, instID string, delOnTerm bool) erro
 func getService(region string) (*ec2.EC2, error) {
 	creds := credentials.NewChainCredentials(
 		[]credentials.Provider{
-			&credentials.EnvProvider{},               // check environment
-			&credentials.SharedCredentialsProvider{}, // check home dir
+			&credentials.EnvProvider{},                                            // check environment
+			&credentials.SharedCredentialsProvider{},                              // check home dir
+			&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New())}, // check metadata
 		},
 	)
 

--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -166,6 +166,12 @@ func (vm *VM) Provision() error {
 		return setNonRootDeleteOnDestroy(svc, vm.InstanceID, true)
 	}
 
+	if vm.Name != "" {
+		if err := vm.SetTag("Name", vm.GetName()); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
ec2 instances where being created without a name. a fix if you want it. 