### PR TITLE
Enable specifying the private IP for AWS/GCP

### DIFF
--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -211,6 +211,10 @@ func instanceInfo(vm *VM) *ec2.RunInstancesInput {
 			},
 		})
 	}
+	var privateIPAddress *string
+	if vm.PrivateIPAddress != "" {
+		privateIPAddress = aws.String(vm.PrivateIPAddress)
+	}
 
 	return &ec2.RunInstancesInput{
 		ImageId:             aws.String(vm.AMI),
@@ -225,6 +229,7 @@ func instanceInfo(vm *VM) *ec2.RunInstancesInput {
 		SubnetId:           sid,
 		SecurityGroupIds:   sgid,
 		IamInstanceProfile: iamInstance,
+		PrivateIpAddress:   privateIPAddress,
 	}
 }
 

--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -76,6 +76,7 @@ type VM struct {
 	InstanceID             string
 	KeyPair                string // required
 	IamInstanceProfileName string
+	PrivateIPAddress       string
 
 	Volumes                      []EBSVolume
 	KeepRootVolumeOnDestroy      bool

--- a/virtualmachine/gcp/util.go
+++ b/virtualmachine/gcp/util.go
@@ -300,6 +300,7 @@ func (svc *googleService) provision() error {
 				},
 				Network:    network.SelfLink,
 				Subnetwork: subnetworkSelfLink,
+				NetworkIP: svc.vm.PrivateIPAddress,
 			},
 		},
 		Scheduling: &googlecloud.Scheduling{

--- a/virtualmachine/gcp/vm.go
+++ b/virtualmachine/gcp/vm.go
@@ -45,9 +45,10 @@ type VM struct {
 
 	Disks []Disk // At least one disk is required, the first one is booted device
 
-	Network       string
-	Subnetwork    string
-	UseInternalIP bool
+	Network          string
+	Subnetwork       string
+	UseInternalIP    bool
+	PrivateIPAddress string
 
 	Scopes  []string //Access scopes
 	Project string   //GCE project


### PR DESCRIPTION
Exposes the PrivateIPAddress variable of AWS's RunInstanceInput, provides more control of the IP Address space