### PR TITLE
Update .travis.yml for Go 1.8. Add unused linter and gofmt -s.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.6
   - 1.7
-  - tip
+  - 1.8
 
 os:
   - linux
@@ -15,7 +14,8 @@ env:
     - BUILD_GOARCH=386
 
 before_install:
-  - go get -u honnef.co/go/simple/cmd/gosimple
+  - go get -u honnef.co/go/tools/cmd/gosimple
+  - go get -u honnef.co/go/tools/cmd/unused
 
 # don't go get deps. will only build with code in vendor directory.
 install: true
@@ -23,6 +23,9 @@ install: true
 script:
   # pkgs avoids testing anything in vendor/
   - pkgs=$(go list ./... | grep -v /vendor/)
+  - go_files=$(find . -iname '*.go' | grep -v vendor/)
+  - test -z $(gofmt -s -l $go_files)
   - go vet $pkgs
   - go test -v -race $pkgs
   - gosimple $pkgs
+  - unused $pkgs

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Supported Providers
 Getting Started
 ================
 
-Go version 1.6+ is required.
+Go version 1.7+ is required.
 
 `go get github.com/apcera/libretto/...`
 

--- a/virtualmachine/aws/util.go
+++ b/virtualmachine/aws/util.go
@@ -25,7 +25,6 @@ const (
 	defaultInstanceType = "t2.micro"
 	defaultAMI          = "ami-5189a661" // ubuntu free tier
 	defaultVolumeSize   = 8              // GB
-	defaultDeviceName   = "/dev/sda1"
 	defaultVolumeType   = "gp2"
 
 	// RegionEnv is the env var for the AWS region.

--- a/virtualmachine/azure/management/util.go
+++ b/virtualmachine/azure/management/util.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sync"
-	"time"
 
 	lvm "github.com/apcera/libretto/virtualmachine"
 
@@ -144,23 +143,6 @@ func (vm *VM) serviceExist(services []hostedservice.HostedService) bool {
 	}
 
 	return false
-}
-
-// waitForReady waits for the VM to go into the desired state.
-func (vm *VM) waitForReady(timeout int, targetState string) error {
-	for i := 0; i < timeout; i++ {
-		state, err := vm.GetState()
-		if err != nil {
-			return err
-		}
-
-		if state == targetState {
-			return nil
-		}
-
-		time.Sleep(1 * time.Second)
-	}
-	return fmt.Errorf(errMsgTimeout, virtualmachine.DeploymentStatusRunning)
 }
 
 func (vm *VM) getDeploymentOptions() virtualmachine.CreateDeploymentOptions {

--- a/virtualmachine/azure/management/vm.go
+++ b/virtualmachine/azure/management/vm.go
@@ -24,9 +24,7 @@ const (
 	PrivateIP = 1
 
 	errGetClient      = "Error to retrieve Azure client %s"
-	errGetDeployment  = "Error to provision Azure VM %s"
 	errGetListService = "Error to list hosted services %s"
-	errMsgTimeout     = "Time out waiting for instance to %s"
 	errProvisionVM    = "Error to provision Azure VM %s"
 )
 

--- a/virtualmachine/gcp/util.go
+++ b/virtualmachine/gcp/util.go
@@ -300,7 +300,7 @@ func (svc *googleService) provision() error {
 				},
 				Network:    network.SelfLink,
 				Subnetwork: subnetworkSelfLink,
-				NetworkIP: svc.vm.PrivateIPAddress,
+				NetworkIP:  svc.vm.PrivateIPAddress,
 			},
 		},
 		Scheduling: &googlecloud.Scheduling{

--- a/virtualmachine/virtualbox/util.go
+++ b/virtualmachine/virtualbox/util.go
@@ -155,10 +155,9 @@ func (vm *VM) requestIPs() []net.IP {
 }
 
 func (vm *VM) waitUntilReady() error {
-	// Check if the vm already has ips before starting the vm
-	// If it does then wait until the timestamp for at least one of them changes.
-	var ips []net.IP
-	ips = vm.requestIPs()
+	// Check if the VM already has IPs before starting the VM. If it does then
+	// wait until the timestamp for at least one of the changes.
+	ips := vm.requestIPs()
 	timestamps := map[string]string{}
 	for k, v := range vm.ipUpdate {
 		timestamps[k] = v

--- a/virtualmachine/virtualbox/vm.go
+++ b/virtualmachine/virtualbox/vm.go
@@ -40,7 +40,6 @@ type NIC struct {
 	Idx           int
 	Backing       Backing
 	BackingDevice string
-	runner        Runner
 }
 
 // Runner is an encapsulation around the vmrun utility.

--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -19,7 +19,6 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/types"
 
 	"golang.org/x/net/context"
@@ -272,14 +271,6 @@ type snapshot struct {
 
 type finder interface {
 	DatacenterList(context.Context, string) ([]*object.Datacenter, error)
-}
-
-type vmwareCollector struct {
-	collector *property.Collector
-}
-
-func (v vmwareCollector) RetrieveOne(c context.Context, mor types.ManagedObjectReference, ps []string, dst interface{}) error {
-	return v.collector.RetrieveOne(c, mor, ps, dst)
 }
 
 type location struct {


### PR DESCRIPTION
- update `.travis.yml` for Go 1.8
- add `gofmt -s` check
- fix `gofmt` issue
- add `unused` check
- delete unused code found by `unused`
- update URL that `gosimple` is fetched from
- update README to only claim support for Go 1.7+