### PR TITLE
Update oauth2 dep

### DIFF
--- a/vendor/golang.org/x/oauth2/clientcredentials/clientcredentials.go
+++ b/vendor/golang.org/x/oauth2/clientcredentials/clientcredentials.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/oauth2/internal"
 )
 
-// Client Credentials Config describes a 2-legged OAuth2 flow, with both the
+// Config describes a 2-legged OAuth2 flow, with both the
 // client application information and the server's endpoint URLs.
 type Config struct {
 	// ClientID is the application's ID.

--- a/vendor/golang.org/x/oauth2/google/sdk.go
+++ b/vendor/golang.org/x/oauth2/google/sdk.go
@@ -160,9 +160,13 @@ var sdkConfigPath = func() (string, error) {
 }
 
 func guessUnixHomeDir() string {
-	usr, err := user.Current()
-	if err == nil {
-		return usr.HomeDir
+	// Prefer $HOME over user.Current due to glibc bug: golang.org/issue/13470
+	if v := os.Getenv("HOME"); v != "" {
+		return v
 	}
-	return os.Getenv("HOME")
+	// Else, fall back to user.Current:
+	if u, err := user.Current(); err == nil {
+		return u.HomeDir
+	}
+	return ""
 }

--- a/vendor/golang.org/x/oauth2/internal/oauth2.go
+++ b/vendor/golang.org/x/oauth2/internal/oauth2.go
@@ -42,7 +42,7 @@ func ParseKey(key []byte) (*rsa.PrivateKey, error) {
 
 func ParseINI(ini io.Reader) (map[string]map[string]string, error) {
 	result := map[string]map[string]string{
-		"": map[string]string{}, // root section
+		"": {}, // root section
 	}
 	scanner := bufio.NewScanner(ini)
 	currentSection := ""

--- a/vendor/golang.org/x/oauth2/internal/token.go
+++ b/vendor/golang.org/x/oauth2/internal/token.go
@@ -91,6 +91,7 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 
 var brokenAuthHeaderProviders = []string{
 	"https://accounts.google.com/",
+	"https://api.codeswholesale.com/oauth/token",
 	"https://api.dropbox.com/",
 	"https://api.dropboxapi.com/",
 	"https://api.instagram.com/",
@@ -101,6 +102,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://api.twitch.tv/",
 	"https://app.box.com/",
 	"https://connect.stripe.com/",
+	"https://graph.facebook.com", // see https://github.com/golang/oauth2/issues/214
 	"https://login.microsoftonline.com/",
 	"https://login.salesforce.com/",
 	"https://oauth.sandbox.trainingpeaks.com/",
@@ -117,6 +119,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://www.strava.com/oauth/",
 	"https://www.wunderlist.com/oauth/",
 	"https://api.patreon.com/",
+	"https://sandbox.codeswholesale.com/oauth/token",
 }
 
 func RegisterBrokenAuthHeaderProvider(tokenURL string) {
@@ -151,9 +154,9 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 	if err != nil {
 		return nil, err
 	}
-	v.Set("client_id", clientID)
 	bustedAuth := !providerAuthHeaderWorks(tokenURL)
 	if bustedAuth && clientSecret != "" {
+		v.Set("client_id", clientID)
 		v.Set("client_secret", clientSecret)
 	}
 	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(v.Encode()))

--- a/vendor/golang.org/x/oauth2/jwt/jwt.go
+++ b/vendor/golang.org/x/oauth2/jwt/jwt.go
@@ -105,7 +105,9 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 	if t := js.conf.Expires; t > 0 {
 		claimSet.Exp = time.Now().Add(t).Unix()
 	}
-	payload, err := jws.Encode(defaultHeader, claimSet, pk)
+	h := *defaultHeader
+	h.KeyID = js.conf.PrivateKeyID
+	payload, err := jws.Encode(&h, claimSet, pk)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/golang.org/x/oauth2/oauth2.go
+++ b/vendor/golang.org/x/oauth2/oauth2.go
@@ -180,7 +180,6 @@ func (c *Config) Exchange(ctx context.Context, code string) (*Token, error) {
 		"grant_type":   {"authorization_code"},
 		"code":         {code},
 		"redirect_uri": internal.CondVal(c.RedirectURL),
-		"scope":        internal.CondVal(strings.Join(c.Scopes, " ")),
 	})
 }
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -330,7 +330,7 @@
 			"importpath": "golang.org/x/oauth2",
 			"repository": "https://go.googlesource.com/oauth2",
 			"vcs": "git",
-			"revision": "f6093e37b6cb4092101a298aba5d794eb570757f",
+			"revision": "b9780ec78894ab900c062d58ee3076cd9b2a4501",
 			"branch": "master",
 			"notests": true
 		},

--- a/virtualmachine/gcp/util.go
+++ b/virtualmachine/gcp/util.go
@@ -3,6 +3,7 @@
 package gcp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -53,7 +54,7 @@ func (vm *VM) getService() (*googleService, error) {
 			Scopes:     vm.Scopes,
 			TokenURL:   tokenURL,
 		}
-		client = config.Client(oauth2.NoContext)
+		client = config.Client(context.Background())
 	} else {
 		client = &http.Client{
 			Timeout: time.Duration(30 * time.Second),


### PR DESCRIPTION
- update `golang.org/x/oauth2` dep to latest master
- replace use of deprecated `oauth2.NoContext` with `context.Background()`
  - issue caught by `staticcheck`

To make sure this doesn't break anything, I vendored it in `apcera-setup` and [ran unit tests](http://tc.apcera.net/viewType.html?buildTypeId=ApceraSetup_BuildForLinux64bit&branch_ApceraSetup=update_libretto_oauth2&tab=buildTypeStatusDiv) and [continuum systests](http://tc.apcera.net/viewType.html?buildTypeId=SystemTests_DeployTestBranchesVSphereDevWorkflowClusterPy&branch_SystemTests=update_libretto_oauth2&tab=buildTypeStatusDiv) (links work for Apcera employees only). Unit tests are green and I'm waiting on the systest results now.

UPDATE: This depends on #116. Once that is merged, the CI checks will pass.