### PR TITLE
Bring back staticcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 
 before_install:
   - go get -u honnef.co/go/tools/cmd/gosimple
+  - go get -u honnef.co/go/tools/cmd/staticcheck
   - go get -u honnef.co/go/tools/cmd/unused
 
 # don't go get deps. will only build with code in vendor directory.
@@ -26,6 +27,7 @@ script:
   - go_files=$(find . -iname '*.go' | grep -v vendor/)
   - test -z $(gofmt -s -l $go_files)
   - go vet $pkgs
+  - staticcheck $pkgs
   - go test -v -race $pkgs
   - gosimple $pkgs
   - unused $pkgs

--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/apcera/libretto/ssh"
@@ -40,6 +41,11 @@ var (
 	// This ensures that aws.VM implements the virtualmachine.VirtualMachine
 	// interface at compile time.
 	_ virtualmachine.VirtualMachine = (*VM)(nil)
+
+	// nextProvision is the wall time when the next call to Provision will be
+	// allowed to proceed. This is part of the rate limiting system.
+	nextProvision time.Time
+	mu            sync.Mutex
 )
 
 var (
@@ -150,6 +156,8 @@ func (vm *VM) SetTags(tags map[string]string) error {
 // there was a problem during creation, if there was a problem adding a tag, or
 // if the VM takes too long to enter "running" state.
 func (vm *VM) Provision() error {
+	wait() // Avoid the AWS rate limit.
+
 	svc, err := getService(vm.Region)
 	if err != nil {
 		return fmt.Errorf("failed to get AWS service: %v", err)
@@ -181,6 +189,50 @@ func (vm *VM) Provision() error {
 	}
 
 	return nil
+}
+
+// wait implements a rate limiter that prevents more than one call every
+// 0.5s. The maximum time that the caller can be delayed is 1m.
+func wait() {
+	const maxWait = 1 * time.Minute
+
+	now := time.Now().UTC()
+	mu.Lock()
+	wait := getWaitTime(now, maxWait)
+	mu.Unlock()
+
+	time.Sleep(wait)
+
+	interval := 500 * time.Millisecond
+	if wait == maxWait {
+		interval = maxWait
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if now.Before(nextProvision) {
+		nextProvision = nextProvision.Add(interval)
+		return
+	}
+	now = time.Now().UTC()
+	nextProvision = now.Add(interval)
+}
+
+// getWaitTime computes the duration to sleep before the caller of wait() is
+// allowed to proceed. Every concurrent call adds 0.5s to the time the
+// subsequent caller must wait, up to a maximum of 1 minute.
+func getWaitTime(now time.Time, maxWait time.Duration) time.Duration {
+	wait := nextProvision.Sub(now) // might be negative
+
+	// When the system clock falls back an hour, the wait time might be an hour.
+	// This sanity check prevents this error.
+	if wait > maxWait {
+		return maxWait
+	}
+	if wait < 0 {
+		return 0
+	}
+	return wait
 }
 
 // GetIPs returns a slice of IP addresses assigned to the VM. The PublicIP or

--- a/virtualmachine/aws/vm.go
+++ b/virtualmachine/aws/vm.go
@@ -32,17 +32,14 @@ const (
 	StatePending = "pending"
 )
 
-// SSHTimeout is the maximum time to wait before failing to GetSSH. This is not
-// thread-safe.
-var SSHTimeout = 5 * time.Minute
-
 var (
+	// SSHTimeout is the maximum time to wait before failing to GetSSH. This is
+	// not thread-safe.
+	SSHTimeout = 5 * time.Minute
+
 	// This ensures that aws.VM implements the virtualmachine.VirtualMachine
 	// interface at compile time.
 	_ virtualmachine.VirtualMachine = (*VM)(nil)
-
-	// limiter rate limits channel to prevent saturating AWS API limits.
-	limiter = time.Tick(time.Millisecond * 500)
 )
 
 var (
@@ -153,7 +150,6 @@ func (vm *VM) SetTags(tags map[string]string) error {
 // there was a problem during creation, if there was a problem adding a tag, or
 // if the VM takes too long to enter "running" state.
 func (vm *VM) Provision() error {
-	<-limiter
 	svc, err := getService(vm.Region)
 	if err != nil {
 		return fmt.Errorf("failed to get AWS service: %v", err)

--- a/virtualmachine/azure/arm/vm.go
+++ b/virtualmachine/azure/arm/vm.go
@@ -114,7 +114,7 @@ func (vm *VM) Provision() error {
 	}
 
 	// Set up private members of the VM
-	tempName := fmt.Sprintf("%s", randStringRunes(5))
+	tempName := randStringRunes(5)
 	if vm.OsFile == "" {
 		vm.OsFile = tempName + "-os-disk.vhd"
 	}

--- a/virtualmachine/openstack/vm.go
+++ b/virtualmachine/openstack/vm.go
@@ -300,9 +300,7 @@ func (vm *VM) Provision() error {
 // returns nil if there was an error obtaining the IPs.
 func (vm *VM) GetIPs() ([]net.IP, error) {
 	server, err := getServer(vm)
-	if err != nil {
-	}
-	if server == nil {
+	if server == nil || err != nil {
 		// Probably need to call Provision first.
 		return nil, err
 	}

--- a/virtualmachine/virtualbox/vm.go
+++ b/virtualmachine/virtualbox/vm.go
@@ -173,7 +173,7 @@ func (vm *VM) GetIPs() ([]net.IP, error) {
 
 // GetState gets the power state of the VM being serviced by this driver.
 func (vm *VM) GetState() (string, error) {
-	stdout, err := runner.RunCombinedError("showvminfo", fmt.Sprintf("%s", vm.Name))
+	stdout, err := runner.RunCombinedError("showvminfo", vm.Name)
 	if err != nil {
 		return "", lvm.WrapErrors(lvm.ErrVMInfoFailed, err)
 	}
@@ -192,7 +192,7 @@ func (vm *VM) GetState() (string, error) {
 // GetInterfaces gets all the network cards attached to this VM
 func (vm *VM) GetInterfaces() ([]NIC, error) {
 	nics := []NIC{}
-	stdout, err := runner.RunCombinedError("showvminfo", fmt.Sprintf("%s", vm.Name))
+	stdout, err := runner.RunCombinedError("showvminfo", vm.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (vm *VM) Provision() error {
 
 	// See comment on mutex definition for details.
 	createMutex.Lock()
-	_, err = runner.RunCombinedError("import", vm.Src, "--vsys", "0", "--vmname", fmt.Sprintf("%s", vm.Name))
+	_, err = runner.RunCombinedError("import", vm.Src, "--vsys", "0", "--vmname", vm.Name)
 	createMutex.Unlock()
 	if err != nil {
 		return err

--- a/virtualmachine/vmrun/util.go
+++ b/virtualmachine/vmrun/util.go
@@ -3,6 +3,7 @@
 package vmrun
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -19,9 +20,17 @@ func copyDir(src string, dest string) error {
 		return err
 	}
 
-	dir, _ := os.Open(src)
+	dir, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
 	// Pass -1 to Readdir to make it read everything into a single slice
 	children, err := dir.Readdir(-1)
+	if err != nil {
+		return fmt.Errorf("failed to read files from directory %q: %v", src, err)
+	}
 
 	for _, child := range children {
 		newSrc := filepath.Join(src, child.Name())

--- a/virtualmachine/vmrun/vm.go
+++ b/virtualmachine/vmrun/vm.go
@@ -324,7 +324,11 @@ func (vm *VM) Provision() error {
 		return err
 	}
 
-	runVMware()
+	_, _, err = runVMware()
+	if err != nil {
+		return err
+	}
+
 	return vm.waitUntilReady()
 }
 


### PR DESCRIPTION
- add `staticcheck` to `.travis.yml`
- fix staticcheck bugs
  - unchecked error
  - file that wasn't closed
  - leaking ticker in `aws/vm.go`

There was a ticker in `aws/vm.go` that had to be removed because it wasn't getting cleaned up by the GC ([details here](https://golang.org/pkg/time/#Tick)). The purpose of this ticker was to avoid hitting AWS rate limits. Really it synched `Provision` calls to 500ms intervals. That's not quite the same as rate limiting, but it sufficed. We should come up with a different approach to rate limiting calls to `Provision`.

~This is branched off #117, which fixes another `staticcheck` bug. It should not be merged until #117 and #116 have been merged.~ UPDATE: rebase off `master`