### PR TITLE
Add nil check before checking vSphere virtual device unit number

### DIFF
--- a/virtualmachine/vsphere/util.go
+++ b/virtualmachine/vsphere/util.go
@@ -214,7 +214,7 @@ var resetUnitNumbers = func(spec *types.OvfCreateImportSpecResult) {
 	s := &spec.ImportSpec.(*types.VirtualMachineImportSpec).ConfigSpec
 	for _, d := range s.DeviceChange {
 		n := d.GetVirtualDeviceConfigSpec().Device.GetVirtualDevice().UnitNumber
-		if *n == 0 {
+		if n != nil && *n == 0 {
 			*n = -1
 		}
 	}


### PR DESCRIPTION
we were seeing a panic in `apcera-setup`, probably due to the recent update of the `vmware/govmomi` dep, from `v0.2.0` -> `v0.13.0` -> `v0.14.0`. basically, a `govmomi` func is now returning `nil` occasionally. the fix is just checking for `nil` before dereferencing. as far as i can tell, there's no other issue. with the `nil` check, i witnessed templates being uploaded correctly and `apcera-setup create` completing normally.