### PR TITLE
Fix SSH close channel race condition

### DIFF
--- a/ssh/mock_ssh.go
+++ b/ssh/mock_ssh.go
@@ -7,6 +7,22 @@ import (
 	"time"
 )
 
+// MockSSHClient represents a Mock Client wrapper.
+type MockSSHClient struct {
+	MockConnect    func() error
+	MockDisconnect func()
+	MockDownload   func(src io.WriteCloser, dst string) error
+	MockRun        func(command string, stdout io.Writer, stderr io.Writer) error
+	MockUpload     func(src io.Reader, dst string, mode uint32) error
+	MockValidate   func() error
+	MockWaitForSSH func(maxWait time.Duration) error
+
+	MockSetSSHPrivateKey func(string)
+	MockGetSSHPrivateKey func() string
+	MockSetSSHPassword   func(string)
+	MockGetSSHPassword   func() string
+}
+
 // Connect calls the mocked connect.
 func (c *MockSSHClient) Connect() error {
 	if c.MockConnect != nil {
@@ -19,9 +35,7 @@ func (c *MockSSHClient) Connect() error {
 func (c *MockSSHClient) Disconnect() {
 	if c.MockDisconnect != nil {
 		c.MockDisconnect()
-		return
 	}
-	return
 }
 
 // Download calls the mocked download.
@@ -68,9 +82,7 @@ func (c *MockSSHClient) WaitForSSH(maxWait time.Duration) error {
 func (c *MockSSHClient) SetSSHPrivateKey(s string) {
 	if c.MockSetSSHPrivateKey != nil {
 		c.MockSetSSHPrivateKey(s)
-		return
 	}
-	return
 }
 
 // GetSSHPrivateKey calls the mocked GetSSHPrivateKey
@@ -85,9 +97,7 @@ func (c *MockSSHClient) GetSSHPrivateKey() string {
 func (c *MockSSHClient) SetSSHPassword(s string) {
 	if c.MockSetSSHPassword != nil {
 		c.MockSetSSHPassword(s)
-		return
 	}
-	return
 }
 
 // GetSSHPassword calls the mocked GetSSHPassword

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -39,8 +39,6 @@ var (
 	ErrUnableToWriteFile = errors.New("Unable to write file")
 	// ErrNotImplemented is returned when a function is not implemented (typically by the Mock implementation).
 	ErrNotImplemented = errors.New("Operation not implemented")
-	// Setup a mutex for the close channel for thread safety.
-	closeMutex sync.Mutex
 )
 
 const (
@@ -98,63 +96,6 @@ type SSHClient struct {
 	close        chan bool
 }
 
-// MockSSHClient represents a Mock Client wrapper.
-type MockSSHClient struct {
-	MockConnect    func() error
-	MockDisconnect func()
-	MockDownload   func(src io.WriteCloser, dst string) error
-	MockRun        func(command string, stdout io.Writer, stderr io.Writer) error
-	MockUpload     func(src io.Reader, dst string, mode uint32) error
-	MockValidate   func() error
-	MockWaitForSSH func(maxWait time.Duration) error
-
-	MockSetSSHPrivateKey func(string)
-	MockGetSSHPrivateKey func() string
-	MockSetSSHPassword   func(string)
-	MockGetSSHPassword   func() string
-}
-
-// dial will attempt to connect to an SSH server.
-var dial = func(network, addr string, config *cssh.ClientConfig) (*cssh.Client, error) {
-	d := net.Dialer{Timeout: Timeout, KeepAlive: 2 * time.Second}
-
-	conn, err := d.Dial(network, addr)
-	if err != nil {
-		return nil, err
-	}
-
-	c, chans, reqs, err := cssh.NewClientConn(conn, addr, config)
-	if err != nil {
-		return nil, err
-	}
-
-	return cssh.NewClient(c, chans, reqs), nil
-}
-
-var readPrivateKey = func(key string) (cssh.AuthMethod, error) {
-	signer, err := cssh.ParsePrivateKey([]byte(key))
-	if err != nil {
-		return nil, err
-	}
-
-	return cssh.PublicKeys(signer), nil
-}
-
-var getAuth = func(c *Credentials, authType string) (cssh.AuthMethod, error) {
-	var (
-		auth cssh.AuthMethod
-		err  error
-	)
-
-	switch authType {
-	case PasswordAuth:
-		return cssh.Password(c.SSHPassword), nil
-	case KeyAuth:
-		return readPrivateKey(c.SSHPrivateKey)
-	}
-	return auth, err
-}
-
 // Connect connects to a machine using SSH.
 func (client *SSHClient) Connect() error {
 	var (
@@ -198,12 +139,8 @@ func (client *SSHClient) Connect() error {
 
 	client.cryptoClient = c
 
-	closeMutex.Lock()
-	defer closeMutex.Unlock()
+	client.close = make(chan bool)
 
-	if client.close == nil {
-		client.close = make(chan bool, 1)
-	}
 	if client.Options.KeepAlive > 0 {
 		go client.keepAlive()
 	}
@@ -227,17 +164,7 @@ func (client *SSHClient) keepAlive() {
 
 // Disconnect should be called when the ssh client is no longer needed, and state can be cleaned up
 func (client *SSHClient) Disconnect() {
-	select {
-	case <-client.close:
-	default:
-		closeMutex.Lock()
-		defer closeMutex.Unlock()
-
-		if client.close != nil {
-			close(client.close)
-			client.close = nil
-		}
-	}
+	client.close <- true
 }
 
 // Download downloads a file via SSH (SCP)
@@ -486,4 +413,45 @@ func (client *SSHClient) GetSSHPassword() string {
 	client.Creds.mu.Lock()
 	defer client.Creds.mu.Unlock()
 	return client.Creds.SSHPassword
+}
+
+// dial will attempt to connect to an SSH server.
+var dial = func(network, addr string, config *cssh.ClientConfig) (*cssh.Client, error) {
+	d := net.Dialer{Timeout: Timeout, KeepAlive: 2 * time.Second}
+
+	conn, err := d.Dial(network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	c, chans, reqs, err := cssh.NewClientConn(conn, addr, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return cssh.NewClient(c, chans, reqs), nil
+}
+
+var readPrivateKey = func(key string) (cssh.AuthMethod, error) {
+	signer, err := cssh.ParsePrivateKey([]byte(key))
+	if err != nil {
+		return nil, err
+	}
+
+	return cssh.PublicKeys(signer), nil
+}
+
+var getAuth = func(c *Credentials, authType string) (cssh.AuthMethod, error) {
+	var (
+		auth cssh.AuthMethod
+		err  error
+	)
+
+	switch authType {
+	case PasswordAuth:
+		return cssh.Password(c.SSHPassword), nil
+	case KeyAuth:
+		return readPrivateKey(c.SSHPrivateKey)
+	}
+	return auth, err
 }


### PR DESCRIPTION
This fixes a race condition on the close channel field. I think the
original intention was to clean up resources, but it's not necessary to
nil out channels to clean them. The garbage collector will take care of
this for us.

The diff looks bigger than it really is because I moved the mock type declaration to `mock_ssh` and moved the SSHClient methods closer to its type definition.