### PR TITLE
Fixed the hanging bug on ssh keepAlive

### DIFF
--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -139,7 +139,7 @@ func (client *SSHClient) Connect() error {
 
 	client.cryptoClient = c
 
-	client.close = make(chan bool)
+	client.close = make(chan bool, 1)
 
 	if client.Options.KeepAlive > 0 {
 		go client.keepAlive()


### PR DESCRIPTION
The channel size must be 1, otherwise the keepAlive() function hangs forever.