### PR TITLE
Fix bad go get command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Getting Started
 
 Go version 1.7+ is required.
 
-`go get -u github.com/apcera/libretto/...`
-
-`go build ./...`
+``` sh
+go get -u github.com/apcera/libretto
+```
 
 Examples
 =========
@@ -40,75 +40,73 @@ AWS
 ----
 
 ``` go
-
 rawKey, err := ioutil.ReadFile(*key)
 if err != nil {
-        return err
+	return err
 }
 
 vm := &aws.VM{
-        Name:         "libretto-aws",
-        AMI:          "ami-984734",
-        InstanceType: "m4.large",
-        SSHCreds: ssh.Credentials{
-                SSHUser:       "ubuntu",
-                SSHPrivateKey: string(rawKey),
-        },
-        Volumes: []aws.EBSVolume{
-            {
-                DeviceName: "/dev/sda1",
-            },
-        },
-        Region:        "ap-northeast-1",
-        KeyPair:       strings.TrimSuffix(filepath.Base(*key), filepath.Ext(*key)),
-        SecurityGroup: "sg-9fdsfds",
+	Name:         "libretto-aws",
+	AMI:          "ami-984734",
+	InstanceType: "m4.large",
+	SSHCreds: ssh.Credentials{
+		SSHUser:       "ubuntu",
+		SSHPrivateKey: string(rawKey),
+	},
+	Volumes: []aws.EBSVolume{
+		{
+			DeviceName: "/dev/sda1",
+		},
+	},
+	Region:        "ap-northeast-1",
+	KeyPair:       strings.TrimSuffix(filepath.Base(*key), filepath.Ext(*key)),
+	SecurityGroup: "sg-9fdsfds",
 }
 
-if err := aws.ValidCredentials(vm.Region); err != nil {
-        return err
+err = aws.ValidCredentials(vm.Region)
+if err != nil {
+	return err
 }
 
-if err := vm.Provision(); err != nil {
-        return err
+err = vm.Provision()
+if err != nil {
+	return err
 }
-
 ```
 
 Azure
 ------
 
 ``` go
-
 vm := &azure.VM{
-   Creds: azure.OAuthCredentials{
-     SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
-     TenantID:       os.Getenv("AZURE_TENANT_ID"),
-     ClientID:       os.Getenv("AZURE_CLIENT_ID"),
-     ClientSecret:   os.Getenv("AZURE_CLIENT_SECRET"),
-   },
-   ImagePublisher:   "Canonical",
-   ImageOffer:       "UbuntuServer",
-   ImageSku:         "14.04.3-LTS",
-   Size:             "Standard_A1",
-   DiskSize:         40 // Set to 0 if you don't want to attach any additional disk
-   Name:             "libretto",
-   ResourceGroup:    "libretto-rg",
-   StorageAccount:   "libretto-sa",
-   StorageContainer: "libretto-sc",
-   SSHCreds: ssh.Credentials{
-     SSHUser:     os.Getenv("AZURE_USER"),
-     SSHPassword: os.Getenv("AZURE_PASSWORD"),
-   },
+	Creds: azure.OAuthCredentials{
+		SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
+		TenantID:       os.Getenv("AZURE_TENANT_ID"),
+		ClientID:       os.Getenv("AZURE_CLIENT_ID"),
+		ClientSecret:   os.Getenv("AZURE_CLIENT_SECRET"),
+	},
+	ImagePublisher:   "Canonical",
+	ImageOffer:       "UbuntuServer",
+	ImageSku:         "14.04.3-LTS",
+	Size:             "Standard_A1",
+	DiskSize:         40, // Set to 0 if you don't want to attach any additional disk
+	Name:             "libretto",
+	ResourceGroup:    "libretto-rg",
+	StorageAccount:   "libretto-sa",
+	StorageContainer: "libretto-sc",
+	SSHCreds: ssh.Credentials{
+		SSHUser:     os.Getenv("AZURE_USER"),
+		SSHPassword: os.Getenv("AZURE_PASSWORD"),
+	},
 
-   NetworkSecurityGroup: "libretto-sg",
-   VirtualNetwork:       "libretto-vn",
-   Subnet:               "libretto-sn",
+	NetworkSecurityGroup: "libretto-sg",
+	VirtualNetwork:       "libretto-vn",
+	Subnet:               "libretto-sn",
 }
 
 if err := vm.Provision(); err != nil {
-      return err
+	return err
 }
-
 ```
 
 Digital Ocean
@@ -117,178 +115,171 @@ Digital Ocean
 ``` go
 token := os.Getenv("DIGITALOCEAN_API_KEY")
 if token == "" {
-    return fmt.Errorf("Please export your DigitalOcean API key to 'DIGITALOCEAN_API_KEY' and run again.")
+	return fmt.Errorf("Please export your DigitalOcean API key to 'DIGITALOCEAN_API_KEY' and run again.")
 }
 config := digitalocean.Config{
-    Name:   defaultDropletName,
-    Region: defaultDropletRegion,
-    Image:  defaultDropletImage,
-    Size:   defaultDropletSize,
+	Name:   defaultDropletName,
+	Region: defaultDropletRegion,
+	Image:  defaultDropletImage,
+	Size:   defaultDropletSize,
 }
 
 vm := digitalocean.VM{
-    APIToken: token,
-    Config:   config,
+	APIToken: token,
+	Config:   config,
 }
 
 if err := vm.Provision(); err != nil {
-    return err
+	return err
 }
 ```
 
 Exoscale
 ---------
 
- ``` go
-
-  vm := exoscale.VM{
-     Config: exoscale.Config{
-       Endpoint:  "https://api.exoscale.ch/compute",
-       APIKey:    os.Getenv("EXOSCALE_API_KEY"),
-       APISecret: os.Getenv("EXOSCALE_API_SECRET"),
-     },
-     Template: exoscale.Template{
-       Name:      "Linux Ubuntu 16.04 LTS 64-bit",
-       StorageGB: 10,
-       ZoneName:  "ch-dk-2",
-     },
-     ServiceOffering: exoscale.ServiceOffering{
-       Name: exoscale.Medium,
-     },
-     SecurityGroups: []exoscale.SecurityGroup{
-       {Name: "default"},
-       {Name: "my sg"},
-     },
-     Zone: exoscale.Zone{
-       Name: "ch-dk-2",
-     },
-     KeypairName: "mydev",
-     Name:        "libretto-exoscale",
-     Userdata: `
+``` go
+vm := exoscale.VM{
+	Config: exoscale.Config{
+		Endpoint:  "https://api.exoscale.ch/compute",
+		APIKey:    os.Getenv("EXOSCALE_API_KEY"),
+		APISecret: os.Getenv("EXOSCALE_API_SECRET"),
+	},
+	Template: exoscale.Template{
+		Name:      "Linux Ubuntu 16.04 LTS 64-bit",
+		StorageGB: 10,
+		ZoneName:  "ch-dk-2",
+	},
+	ServiceOffering: exoscale.ServiceOffering{
+		Name: exoscale.Medium,
+	},
+	SecurityGroups: []exoscale.SecurityGroup{
+		{Name: "default"},
+		{Name: "my sg"},
+	},
+	Zone: exoscale.Zone{
+		Name: "ch-dk-2",
+	},
+	KeypairName: "mydev",
+	Name:        "libretto-exoscale",
+	Userdata: `
 # cloud-config
 manage_etc_hosts: true
 fqdn: new.host
 `,
-  }
+}
 
-  if err := vm.Provision(); err != nil {
-    fmt.Printf("Error provisioning machine: %s\n", err)
-  }
+if err := vm.Provision(); err != nil {
+	fmt.Printf("Error provisioning machine: %s\n", err)
+}
 
-  // get VM ID polling every 5 seconds, timeout after 30
-  vm.WaitVMCreation(30, 5)
-
-  ```
+// get VM ID polling every 5 seconds, timeout after 30
+vm.WaitVMCreation(30, 5)
+```
 
  Google Cloud Platform
 ----------
 
 ``` go
-
 vm := &gcp.VM{
-    Name:          "libretto-vm-1",
-    Zone:          "us-central1-a",
-    MachineType:   "n1-standard-1",
-    SourceImage:   "ubuntu-1404-trusty-v20160516",
-    Disks: []gcp.Disk{
-      {
-        DiskType:   "pd-standard",
-        DiskSizeGb: 10,
-        AutoDelete: true,
-      },
-      {
-        DiskType:   "pd-standard",
-        DiskSizeGb: 500,
-        AutoDelete: true,
-        Name:       "addtional-disk",
-      },
-    },
-    Preemptible:   false,
-    Network:       "default",
-    Subnetwork:    "default",
-    UseInternalIP: false,
-    Project:       os.Getenv("YOUR-GOOGLE-PROJECT"),
-    Scopes:        scopes,
+	Name:        "libretto-vm-1",
+	Zone:        "us-central1-a",
+	MachineType: "n1-standard-1",
+	SourceImage: "ubuntu-1404-trusty-v20160516",
+	Disks: []gcp.Disk{
+		{
+			DiskType:   "pd-standard",
+			DiskSizeGb: 10,
+			AutoDelete: true,
+		},
+		{
+			DiskType:   "pd-standard",
+			DiskSizeGb: 500,
+			AutoDelete: true,
+			Name:       "addtional-disk",
+		},
+	},
+	Preemptible:   false,
+	Network:       "default",
+	Subnetwork:    "default",
+	UseInternalIP: false,
+	Project:       os.Getenv("YOUR-GOOGLE-PROJECT"),
+	Scopes:        scopes,
 
-    AccountFile: accountFile,
-    SSHCreds: ssh.Credentials{
-      SSHUser:       "ubuntu",
-      SSHPrivateKey: string(sshPrivateKey),
-    },
-    SSHPublicKey: string(sshPublicKey),
-    Tags:         []string{"libretto"},
-  }
+	AccountFile: accountFile,
+	SSHCreds: ssh.Credentials{
+		SSHUser:       "ubuntu",
+		SSHPrivateKey: string(sshPrivateKey),
+	},
+	SSHPublicKey: string(sshPublicKey),
+	Tags:         []string{"libretto"},
+}
 
-  err := vm.Provision()
-  if err != nil {
-        return err
-  }
- ```
+if err := vm.Provision(); err != nil {
+	return err
+}
+```
 
  Openstack
 ----------
 
 ``` go
+metadata := openstack.NewDefaultImageMetadata()
+volume := openstack.NewDefaultVolume()
 
+// Optional
+cloudInit, err := ioutil.ReadFile("/your/user/data")
+if err != nil {
+	return err
+}
 
-  metadata := openstack.NewDefaultImageMetadata()
-  volume := openstack.NewDefaultVolume()
+vm := &openstack.VM{
+	IdentityEndpoint: os.Getenv("OS_AUTH_URL"),
+	Username:         os.Getenv("OS_USERNAME"),
+	Password:         os.Getenv("OS_PASSWORD"),
+	Region:           os.Getenv("OS_REGION_NAME"),
+	TenantName:       os.Getenv("OS_TENANT_NAME"),
+	FlavorName:       "m1.medium",
+	ImageID:          "",
+	ImageMetadata:    metadata,
+	ImagePath:        os.Getenv("OS_IMAGE_PATH"),
+	Volume:           volume,
+	InstanceID:       "",
+	Name:             "test",
+	Networks:         []string{"eab29109-3363-4b03-8a56-8fe27b71f3a0"},
+	FloatingIPPool:   "net04_ext",
+	FloatingIP:       nil,
+	SecurityGroup:    "test",
+	AdminPassword:    os.Getenv("OS_ADMIN_PASSWORD"),
+	UserData:         cloudInit,
+	Credentials: ssh.Credentials{
+		SSHUser:     "ubuntu",
+		SSHPassword: "ubuntu",
+	},
+}
 
-  // Optional
-  cloudInit, err := ioutil.ReadFile("/your/user/data")
-  if err != nil {
-      return err
-  }
-
-  vm := &openstack.VM{
-    IdentityEndpoint: os.Getenv("OS_AUTH_URL"),
-    Username:         os.Getenv("OS_USERNAME"),
-    Password:         os.Getenv("OS_PASSWORD"),
-    Region:           os.Getenv("OS_REGION_NAME"),
-    TenantName:       os.Getenv("OS_TENANT_NAME"),
-    FlavorName:       "m1.medium",
-    ImageID:          "",
-    ImageMetadata:    metadata,
-    ImagePath:        os.Getenv("OS_IMAGE_PATH"),
-    Volume:           volume,
-    InstanceID:       "",
-    Name:             "test",
-    Networks:         []string{"eab29109-3363-4b03-8a56-8fe27b71f3a0"},
-    FloatingIPPool:   "net04_ext",
-    FloatingIP:       nil,
-    SecurityGroup:    "test",
-    AdminPassword:    os.Getenv("OS_ADMIN_PASSWORD"),
-    UserData:         cloudInit,
-    Credentials: ssh.Credentials{
-      SSHUser:     "ubuntu",
-      SSHPassword: "ubuntu",
-    },
-  }
-
-  err := vm.Provision()
-  if err != nil {
-        return err
-  }
- ```
+err = vm.Provision()
+if err != nil {
+	return err
+}
+```
 
  Virtualbox
 -----------
 
 ``` go
-
 var config virtualbox.Config
 config.NICs = []virtualbox.NIC{
-    virtualbox.NIC{Idx: 1, Backing: virtualbox.Bridged, BackingDevice: "en0: Wi-Fi (AirPort)"},
+	virtualbox.NIC{Idx: 1, Backing: virtualbox.Bridged, BackingDevice: "en0: Wi-Fi (AirPort)"},
 }
 vm := virtualbox.VM{Src: "/Users/Admin/vm-bfb21a62-60c5-11e5-9fc5-a45e60e45ad5.ova",
-    Credentials: ssh.Credentials{
-        SSHUser:     "ubuntu",
-        SSHPassword: "ubuntu",
-    },
-    Config: config,
+	Credentials: ssh.Credentials{
+		SSHUser:     "ubuntu",
+		SSHPassword: "ubuntu",
+	},
+	Config: config,
 }
 if err := vm.Provision(); err != nil {
-    return err
+	return err
 }
 ```
 
@@ -296,31 +287,30 @@ vSphere
 --------
 
 ``` go
-
 vm := &vsphere.VM{
-        Host:       "10.2.1.11",
-        Username:   "username",
-        Password:   "password",
-        Datacenter: "test-dc",
-        Datastores: []string{"datastore1", "datastore2"},
-        Networks:    map[string]string{"nat": "network1"},
-        Credentials: ssh.Credentials{
-            SSHUser:     "ubuntu",
-            SSHPassword: "ubuntu",
-        },
-        SkipExisting: true,
-        Insecure:     true,
-        Destination: vsphere.Destination{
-            DestinationName: "Host1",
-            DestinationType: "host",
-            HostSystem:      "",
-        },
-        Name: "test-vm",
-        Template: "test-template",
-        OvfPath: "/Users/Test/Downloads/file.ovf",
+	Host:       "10.2.1.11",
+	Username:   "username",
+	Password:   "password",
+	Datacenter: "test-dc",
+	Datastores: []string{"datastore1", "datastore2"},
+	Networks:   map[string]string{"nat": "network1"},
+	Credentials: ssh.Credentials{
+		SSHUser:     "ubuntu",
+		SSHPassword: "ubuntu",
+	},
+	SkipExisting: true,
+	Insecure:     true,
+	Destination: vsphere.Destination{
+		DestinationName: "Host1",
+		DestinationType: "host",
+		HostSystem:      "",
+	},
+	Name:     "test-vm",
+	Template: "test-template",
+	OvfPath:  "/Users/Test/Downloads/file.ovf",
 }
 if err := vm.Provision(); err != nil {
-        return err
+	return err
 }
 ```
 
@@ -331,18 +321,18 @@ VMware Fusion/Workstation (vmrun)
 ``` go
 var config vmrun.Config
 config.NICs = []vmrun.NIC{
-    vmrun.NIC{Idx: 0, Backing: vmrun.Nat, BackingDevice: "en0"},
+	vmrun.NIC{Idx: 0, Backing: vmrun.Nat, BackingDevice: "en0"},
 }
 vm := vmrun.VM{Src: "/Users/Admin/vmware_desktop/trusty-orchestrator-dev.vmx",
-    Dst: "/Users/Admin/Documents/VMs",
-    Credentials: ssh.Credentials{
-        SSHUser:     "ubuntu",
-        SSHPassword: "ubuntu",
-    },
-    Config: config,
+	Dst: "/Users/Admin/Documents/VMs",
+	Credentials: ssh.Credentials{
+		SSHUser:     "ubuntu",
+		SSHPassword: "ubuntu",
+	},
+	Config: config,
 }
 if err := vm.Provision(); err != nil {
-    return err
+	return err
 }
 ```
 
@@ -352,8 +342,8 @@ FAQ
 
 * Why write Libretto?
 
-We couldn't find a suitable Golang binding for this functionality, so we
-created this library. There are a couple of similar libraries but not in golang
+We couldn't find a suitable Golang binding for this functionality, so we created
+this library. There are a couple of similar libraries but not in golang
 (fog.io in ruby, jcloud in java, libcloud in python).
 
 Docker Machine is an effort toward that direction, but it is very Docker
@@ -362,14 +352,13 @@ number of parameters, but reduces the flexibility of the tool.
 
 * What is the scope for Libretto?
 
-Virtual machine creation and life cycle
-management as well as common configuration steps during a deploy such as
-configuring SSH keys.
+Virtual machine creation and life cycle management as well as common
+configuration steps during a deploy such as configuring SSH keys.
 
 * Why use this library over other tools?
 
-Actively used and developed. Can be called natively from Go in a Go application
-instead of shelling out to other tools.
+Can be called natively from Go in a Go application instead of shelling out to
+other tools.
 
 Known Issues
 =============
@@ -399,7 +388,7 @@ the Linux, Windows and OS X platforms unless it is a platform specific provider
 in which case it should at least compile and return a descriptive error.
 
 Dependencies should be vendored using [`dep ensure`](https://github.com/golang/dep),
-followed by [`govend --prune`](https://github.com/govend/govend).
+followed by [`dep prune`](https://github.com/golang/dep).
 
 Errors should be lower case so that they can be wrapped by the calling code. If
 possible, types defined in the top level `virtualmachine` package should be


### PR DESCRIPTION
### changes
* Fix bad `go get` command
* Delete instructions to `go build`
* Fix code samples not using `gofmt`.
* Fix syntax errors in code samples.
* Fix old reference to using `govend --prune` instead of `dep prune`.