### PR TITLE
Log out from vCenter sessions

### DIFF
--- a/virtualmachine/vsphere/vm.go
+++ b/virtualmachine/vsphere/vm.go
@@ -357,7 +357,10 @@ func (vm *VM) Provision() (err error) {
 	}
 
 	// Cancel the sdk context
-	defer vm.cancel()
+	defer func() {
+		vm.client.Logout(vm.ctx)
+		vm.cancel()
+	}()
 
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
@@ -425,7 +428,10 @@ func (vm *VM) GetIPs() ([]net.IP, error) {
 	if err := SetupSession(vm); err != nil {
 		return nil, err
 	}
-	defer vm.cancel()
+	defer func() {
+		vm.client.Logout(vm.ctx)
+		vm.cancel()
+	}()
 
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
@@ -464,7 +470,10 @@ func (vm *VM) Destroy() (err error) {
 	if err := SetupSession(vm); err != nil {
 		return err
 	}
-	defer vm.cancel()
+	defer func() {
+		vm.client.Logout(vm.ctx)
+		vm.cancel()
+	}()
 
 	state, err := getState(vm)
 	if err != nil {
@@ -552,8 +561,10 @@ func (vm *VM) GetState() (state string, err error) {
 	if err := SetupSession(vm); err != nil {
 		return "", lvm.ErrVMInfoFailed
 	}
-	defer vm.cancel()
-
+	defer func() {
+		vm.client.Logout(vm.ctx)
+		vm.cancel()
+	}()
 	state, err = getState(vm)
 	if err != nil {
 		return "", err
@@ -575,7 +586,11 @@ func (vm *VM) Suspend() (err error) {
 	if err := SetupSession(vm); err != nil {
 		return err
 	}
-	defer vm.cancel()
+
+	defer func() {
+		vm.client.Logout(vm.ctx)
+		vm.cancel()
+	}()
 
 	// Get a reference to the datacenter with host and vm folders populated
 	dcMo, err := GetDatacenter(vm)
@@ -606,7 +621,11 @@ func (vm *VM) Halt() (err error) {
 	if err := SetupSession(vm); err != nil {
 		return err
 	}
-	defer vm.cancel()
+	defer func() {
+		vm.client.Logout(vm.ctx)
+		vm.cancel()
+	}()
+
 	return halt(vm)
 }
 
@@ -615,7 +634,11 @@ func (vm *VM) Start() (err error) {
 	if err := SetupSession(vm); err != nil {
 		return err
 	}
-	defer vm.cancel()
+	defer func() {
+		vm.client.Logout(vm.ctx)
+		vm.cancel()
+	}()
+
 	return start(vm)
 }
 


### PR DESCRIPTION
This commit ensures that we log out of the vCenter session we create for
each request. Previously, we were not logging out and potentially
leaving an unbounded number of active sessons hanging around.