### PR TITLE
Don't build and test on 386 arch in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ os:
   - linux
   - osx
 
-env:
-  matrix:
-    - BUILD_GOARCH=amd64
-    - BUILD_GOARCH=386
-
 matrix:
   allow_failures:
     - go: tip


### PR DESCRIPTION
Travis runs are really slow. We can speed them up by not testing on the 386 (32-bit) architecture. The world has moved on from 32-bit processors and we shouldn't waste time testing on them.