### PR TITLE
Require ssh.Upload caller to pass file size

### DIFF
--- a/ssh/mock_ssh.go
+++ b/ssh/mock_ssh.go
@@ -13,7 +13,7 @@ type MockSSHClient struct {
 	MockDisconnect func()
 	MockDownload   func(src io.WriteCloser, dst string) error
 	MockRun        func(command string, stdout io.Writer, stderr io.Writer) error
-	MockUpload     func(src io.Reader, dst string, mode uint32) error
+	MockUpload     func(src io.Reader, dst string, size int, mode uint32) error
 	MockValidate   func() error
 	MockWaitForSSH func(maxWait time.Duration) error
 
@@ -55,9 +55,9 @@ func (c *MockSSHClient) Run(command string, stdout io.Writer, stderr io.Writer) 
 }
 
 // Upload calls the mocked upload
-func (c *MockSSHClient) Upload(src io.Reader, dst string, mode uint32) error {
+func (c *MockSSHClient) Upload(src io.Reader, dst string, size int, mode uint32) error {
 	if c.MockUpload != nil {
-		return c.MockUpload(src, dst, mode)
+		return c.MockUpload(src, dst, size, mode)
 	}
 	return ErrNotImplemented
 }

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -4,11 +4,9 @@ package ssh
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -60,7 +58,7 @@ type Client interface {
 	Disconnect()
 	Download(src io.WriteCloser, dst string) error
 	Run(command string, stdout io.Writer, stderr io.Writer) error
-	Upload(src io.Reader, dst string, mode uint32) error
+	Upload(src io.Reader, dst string, size int, mode uint32) error
 	Validate() error
 	WaitForSSH(maxWait time.Duration) error
 
@@ -290,18 +288,14 @@ func (client *SSHClient) Run(command string, stdout io.Writer, stderr io.Writer)
 	return session.Run(command)
 }
 
-// Upload uploads a new file via SSH (SCP)
-func (client *SSHClient) Upload(src io.Reader, dst string, mode uint32) error {
-	fileContent, err := ioutil.ReadAll(src)
-	if err != nil {
-		return err
-	}
-
+// Upload uploads a new file via SSH (SCP). dst is the destination path for the
+// file on the remote machine. size is the number of bytes to be uploaded. mode
+// is the permissions the file should have, e.g. 0744.
+func (client *SSHClient) Upload(src io.Reader, dst string, size int, mode uint32) error {
 	session, err := client.cryptoClient.NewSession()
 	if err != nil {
 		return err
 	}
-
 	defer session.Close()
 
 	w, err := session.StdinPipe()
@@ -321,8 +315,8 @@ func (client *SSHClient) Upload(src io.Reader, dst string, mode uint32) error {
 		defer wg.Done()
 
 		// Signals to the SSH receiver that content is being passed.
-		fmt.Fprintf(w, "C%#o %d %s\n", mode, len(fileContent), remoteFileName)
-		_, err = io.Copy(w, bytes.NewReader(fileContent))
+		fmt.Fprintf(w, "C%#o %d %s\n", mode, size, remoteFileName)
+		_, err = io.Copy(w, src)
 		if err != nil {
 			errorChan <- err
 			return


### PR DESCRIPTION
This prevents us from having to drain the reader, loading it entirely into memory, just to get the file size. The scp protocol requires that we know the file size ahead of time.

WARNING: This is a breaking change. We need to update the version tag.