### PR TITLE
Fix string -> bool bug in Azure template

### DIFF
--- a/virtualmachine/azure/arm/templates.go
+++ b/virtualmachine/azure/arm/templates.go
@@ -25,7 +25,7 @@ const Linux = `{
     },
     "nic": {
       "type": "string"
-    },    
+    },
     "os_file": {
       "type": "string"
     },
@@ -144,7 +144,7 @@ const Linux = `{
           "computerName": "[parameters('vm_name')]",
           "adminUsername": "[parameters('username')]",
           "linuxConfiguration": {
-            "disablePasswordAuthentication": "true",
+            "disablePasswordAuthentication": true,
             "ssh": {
               "publicKeys": [
                 {
@@ -181,7 +181,7 @@ const Linux = `{
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
-             "enabled": "false"
+             "enabled": false
           }
         }
       }


### PR DESCRIPTION
We use Azure resource group templates, which are analagous to CloudFormation templates in AWS. The template has two values, `"true"`, and `"false"` that are strings instead of booleans. The Azure API ignores the invalid keys.